### PR TITLE
Abstract swapper stream as part of swapper trait

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -184,6 +184,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +419,7 @@ name = "breez-liquid-sdk"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bip39",
  "boltz-client",
  "chrono",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -264,6 +264,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +523,7 @@ name = "breez-liquid-sdk"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bip39",
  "boltz-client",
  "chrono",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -35,6 +35,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 url = "2.5.0"
 futures-util = { version = "0.3.28", default-features = false, features = ["sink", "std"] }
+async-trait = "0.1.80"
 
 # Pin these versions to fix iOS build issues
 security-framework = "=2.10.0"

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "frb")]
 pub mod bindings;
-pub(crate) mod boltz_status_stream;
 pub mod error;
 pub(crate) mod event;
 #[cfg(feature = "frb")]

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
     time::{Duration, UNIX_EPOCH},
 };
-
+use async_trait::async_trait;
 use anyhow::{anyhow, Result};
 use boltz_client::lightning_invoice::Bolt11InvoiceDescription;
 use boltz_client::swaps::boltzv2;
@@ -33,9 +33,8 @@ use tokio::time::MissedTickBehavior;
 
 use crate::error::LiquidSdkError;
 use crate::model::PaymentState::*;
-use crate::swapper::{BoltzSwapper, Swapper};
-use crate::{
-    boltz_status_stream::BoltzStatusStream,
+use crate::swapper::{BoltzSwapper, ReconnectHandler, Swapper, SwapperStatusStream};
+use crate::{    
     ensure_sdk,
     error::{LiquidSdkResult, PaymentError},
     event::EventManager,
@@ -59,7 +58,7 @@ pub struct LiquidSdk {
     lwk_signer: SwSigner,
     persister: Arc<Persister>,
     event_manager: Arc<EventManager>,
-    status_stream: Arc<BoltzStatusStream>,
+    status_stream: Arc<dyn SwapperStatusStream>,    
     swapper: Arc<dyn Swapper>,
     is_started: RwLock<bool>,
     shutdown_sender: watch::Sender<()>,
@@ -99,19 +98,19 @@ impl LiquidSdk {
         let persister = Arc::new(Persister::new(&config.working_dir, config.network)?);
         persister.init()?;
 
-        let event_manager = Arc::new(EventManager::new());
-        let status_stream = Arc::new(BoltzStatusStream::new(&config.boltz_url, persister.clone()));
+        let event_manager = Arc::new(EventManager::new());        
         let (shutdown_sender, shutdown_receiver) = watch::channel::<()>(());
 
         let swapper = Arc::new(BoltzSwapper::new(config.clone()));
+        let status_stream = Arc::<dyn SwapperStatusStream>::from(swapper.create_status_stream());
 
         let sdk = Arc::new(LiquidSdk {
             config,
             lwk_wollet: Arc::new(Mutex::new(lwk_wollet)),
             lwk_signer: opts.signer,
-            persister,
+            persister: persister.clone(),
             event_manager,
-            status_stream,
+            status_stream: status_stream.clone(),            
             swapper,
             is_started: RwLock::new(false),
             shutdown_sender,
@@ -159,12 +158,12 @@ impl LiquidSdk {
                 }
             }
         });
-
-        self.status_stream
-            .clone()
-            .track_pending_swaps(self.shutdown_receiver.clone())
-            .await;
-
+        
+        let reconnect_handler = Box::new(SwapperReconnectHandler{
+            persister: self.persister.clone(),
+            status_stream: self.status_stream.clone(),        
+        });
+        self.status_stream.clone().start(reconnect_handler, self.shutdown_receiver.clone()).await;
         self.track_swap_updates().await;
         self.track_refundable_swaps().await;
 
@@ -1446,7 +1445,30 @@ impl LiquidSdk {
     /// An error is thrown if a global logger is already configured.
     pub fn init_logging(log_dir: &str, app_logger: Option<Box<dyn log::Log>>) -> Result<()> {
         crate::logger::init_logging(log_dir, app_logger)
-    }
+    }    
+}
+
+struct SwapperReconnectHandler {
+  persister: Arc<Persister>,
+  status_stream: Arc<dyn SwapperStatusStream>,
+}
+
+#[async_trait]
+impl ReconnectHandler for SwapperReconnectHandler {
+  async fn on_stream_reconnect(&self) {
+      match self.persister.list_ongoing_swaps() {
+          Ok(initial_ongoing_swaps) => {
+              info!("On stream reconnection, got {} initial ongoing swaps", initial_ongoing_swaps.len());
+              for ongoing_swap in initial_ongoing_swaps {
+                  match self.status_stream.track_swap_id(&ongoing_swap.id()) {
+                      Ok(_) => info!("Tracking ongoing swap: {}", ongoing_swap.id()),
+                      Err(e) => error!("Failed to track ongoing swap: {e:?}"),                  
+                  }
+              }
+          }
+          Err(e) => error!("Failed to list initial ongoing swaps: {e:?}"),
+      }
+  }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR moves the boltz status stream behind its own trait and as part of the swapper API.
Also took the opportunity to move persistent access out of the swapper trait by adding a ReconectHandler so the user of the trait has the opportunity (hook) to subscribe new list on every reconnection.