### PR TITLE
Publish CI fixes

### DIFF
--- a/.github/workflows/build-language-bindings.yml
+++ b/.github/workflows/build-language-bindings.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: bindings-python
-          path: lib/bindings/ffi/langs/python/breez_liquid_sdk.py
+          path: lib/bindings/ffi/python/breez_liquid_sdk.py
 
 #      - name: Build C# binding
 #        if: ${{ inputs.csharp }}

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -326,4 +326,5 @@ jobs:
       publish: ${{ needs.setup.outputs.publish == 'true' }}
     secrets:
       REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
+      SWIFT_RELEASE_TOKEN: ${{ secrets.SWIFT_RELEASE_TOKEN }}
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -84,7 +84,7 @@ jobs:
           # We're waiting for at most 60s before triggering the Jitpack build to give our Maven repo
           # some time to process the just uploaded files (the Jitpack build is dependent upon them being available).
           # If anything fails here, we'll still finish sucessfully as this is an optional optimization.
-          timeout 60 bash -c 'while [[ "$(curl --output /dev/null --silent --head --write-out ''%{http_code}'' https://mvn.breez.technology/releases/breez_liquid_sdk/bindings-android/${{ inputs.package-version }}/android-${{ inputs.package-version }}.pom)" != "200" ]]; do echo "Waiting for package to be published on mvn.breez.technology..." && sleep 5; done && echo "Package found."' || echo "Package not found." && true
+          timeout 60 bash -c 'while [[ "$(curl --output /dev/null --silent --head --write-out ''%{http_code}'' https://mvn.breez.technology/releases/breez_liquid_sdk/bindings-android/${{ inputs.package-version }}/bindings-android-${{ inputs.package-version }}.pom)" != "200" ]]; do echo "Waiting for package to be published on mvn.breez.technology..." && sleep 5; done && echo "Package found."' || echo "Package not found." && true
           echo "Attempting to trigger Jitpack build..."
           curl -s -m 30 https://jitpack.io/api/builds/com.github.breez/breez-liquid-sdk/${{ inputs.package-version }} || true
           echo "Done"

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -53,7 +53,7 @@ jobs:
           path: lib/bindings/langs/android/lib/src/main/kotlin
 
       - name: Build Android project
-        working-directory: lib/bindings/android
+        working-directory: lib/bindings/langs/android
         env:
           ORG_GRADLE_PROJECT_libraryVersion: ${{ inputs.package-version || '0.0.1' }}
         run: ./gradlew assemble
@@ -66,7 +66,7 @@ jobs:
         
       - name: Publish artifacts
         if: ${{ inputs.publish }}
-        working-directory: lib/bindings/android
+        working-directory: lib/bindings/langs/android
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BREEZ_MVN_USERNAME: ${{ secrets.BREEZ_MVN_USERNAME }}

--- a/.github/workflows/publish-kotlin-multiplatform.yml
+++ b/.github/workflows/publish-kotlin-multiplatform.yml
@@ -73,7 +73,7 @@ jobs:
           path: lib/bindings/langs/kotlin-multiplatform/breez-liquid-sdk-kmp/src/lib/ios-simulator-x64
 
       - name: Build Kotlin Multiplatform project
-        working-directory: lib/bindings/kotlin-multiplatform
+        working-directory: lib/bindings/langs/kotlin-multiplatform
         env:
           ORG_GRADLE_PROJECT_libraryVersion: ${{ inputs.package-version || '0.0.1' }}
         run: ./gradlew :breez-liquid-sdk-kmp:assemble
@@ -86,7 +86,7 @@ jobs:
         
       - name: Publish artifacts
         if: ${{ inputs.publish }}
-        working-directory: lib/bindings/kotlin-multiplatform
+        working-directory: lib/bindings/langs/kotlin-multiplatform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BREEZ_MVN_USERNAME: ${{ secrets.BREEZ_MVN_USERNAME }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -55,19 +55,19 @@ jobs:
       - name: Clean up downloaded files
         run: |
           rm -f lib/bindings/langs/python/src/breez_liquid_sdk/*.a
-          ls -R lib/bindings/python
+          ls -R lib/bindings/langs/python
 
       - name: Update package version
         if: ${{ inputs.package-version }}
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: sed -i.bak -e 's/    version=".*",/    version="${{ inputs.package-version }}",/' setup.py
 
       - name: Install dependencies
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: pip3 install wheel setuptools
 
       - name: Build wheel
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: python3 setup.py bdist_wheel --plat-name macosx_11_0_universal2 --verbose
 
       - name: List wheel contents
@@ -110,15 +110,15 @@ jobs:
 
       - name: Update package version
         if: ${{ inputs.package-version }}
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: sed -i.bak -e 's/    version=".*",/    version="${{ inputs.package-version }}",/' setup.py
 
       - name: Install dependencies
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: pip3 install wheel setuptools
 
       - name: "Build wheel"
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: python3 setup.py bdist_wheel --plat-name manylinux_2_31_${{ matrix.arch }} --verbose
 
       - uses: actions/upload-artifact@v3
@@ -178,15 +178,15 @@ jobs:
 
       - name: Update package version
         if: ${{ inputs.package-version }}
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: (Get-Content setup.py) | Foreach-Object {$_ -replace '    version=".*",', ('    version="${{ inputs.package-version }}",')} | Set-Content setup.py
 
       - name: Install dependencies
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: python -m pip install --upgrade pip twine wheel setuptools
 
       - name: "Build wheel"
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: python -m setup bdist_wheel --plat-name ${{ matrix.arch }} --verbose
 
       - uses: actions/upload-artifact@v3
@@ -210,7 +210,7 @@ jobs:
           path: lib/bindings/langs/python/dist/
 
       - name: Clean downloaded contents
-        working-directory: lib/bindings/python
+        working-directory: lib/bindings/langs/python
         run: |
           find dist -maxdepth 1 ! -path dist ! -name "python-wheel-*" -exec rm -rf {} \;
           ls -laR dist

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -23,6 +23,9 @@ on:
       REPO_SSH_KEY:
         description: 'ssh key to commit to the breez-liquid-sdk-swift repository'
         required: true
+      SWIFT_RELEASE_TOKEN:
+        description: 'github token to release to the breez-liquid-sdk-swift repository'
+        required: true
       COCOAPODS_TRUNK_TOKEN:
         description: 'cocoapods trunk token'
         required: true
@@ -118,13 +121,14 @@ jobs:
 
       - name: Release and attach XCFramework binary artifact
         if: ${{ inputs.publish }}
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          repo: breez/breez-liquid-sdk-swift
-          artifacts: "build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework.zip"
-          tag: ${{ inputs.package-version || '0.0.1' }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ inputs.package-version || '0.0.1' }}
+          repository: breez/breez-liquid-sdk-swift
+          files: |
+            build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework.zip
+          tag_name: ${{ inputs.package-version || '0.0.1' }}
+          generate_release_notes: false
+          token: ${{ secrets.SWIFT_RELEASE_TOKEN }}
           prerelease: true
 
       - name: Push update to Cocoapods trunk

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -73,10 +73,10 @@ jobs:
       - name: Copy swift bindings
         run: |
           mkdir -p build/lib/bindings/langs/swift/Sources/BreezLiquidSDK
-          cp langs/swift/BreezLiquidSDK.swift build/lib/bindings/langs/swift/Sources/BreezLiquidSDK/BreezLiquidSDK.swift
-          cp langs/swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64/breez_liquid_sdkFFI.framework/Headers
-          cp langs/swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_liquid_sdkFFI.framework/Headers
-          cp langs/swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/macos-arm64_x86_64/breez_liquid_sdkFFI.framework/Headers
+          cp swift/BreezLiquidSDK.swift build/lib/bindings/langs/swift/Sources/BreezLiquidSDK/BreezLiquidSDK.swift
+          cp swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64/breez_liquid_sdkFFI.framework/Headers
+          cp swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_liquid_sdkFFI.framework/Headers
+          cp swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/macos-arm64_x86_64/breez_liquid_sdkFFI.framework/Headers
           mkdir -p build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
           cp aarch64-apple-ios/libbreez_liquid_sdk_bindings.a build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
           mkdir -p build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
@@ -84,16 +84,16 @@ jobs:
           cp darwin-universal/libbreez_liquid_sdk_bindings.a build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/macos-arm64_x86_64/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
 
       - name: Compress XCFramework
-        working-directory: build/lib/bindings/swift
+        working-directory: build/lib/bindings/langs/swift
         run: |
           zip -9 -r breez_liquid_sdkFFI.xcframework.zip breez_liquid_sdkFFI.xcframework
           echo "XCF_CHECKSUM=`swift package compute-checksum breez_liquid_sdkFFI.xcframework.zip`" >> $GITHUB_ENV
 
       - name: Update Swift Package definition
-        working-directory: build/lib/bindings/swift
+        working-directory: build/lib/bindings/langs/swift
         run: |
-          sed 's#.binaryTarget(name: "breez_liquid_sdkFFI", path: "./breez_liquid_sdkFFI.xcframework"),#.binaryTarget(name: "breez_liquid_sdkFFI", url: "https://github.com/breez/breez-liquid-sdk-langs/swift/releases/download/${{ inputs.package-version || '0.0.1' }}/breez_liquid_sdkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#;/.testTarget(name: "BreezLiquidSDKTests", dependencies: \["BreezLiquidSDK"\]),/d' Package.swift > ../../../../dist/Package.swift
-          cp -r Sources ../../../../dist
+          sed 's#.binaryTarget(name: "breez_liquid_sdkFFI", path: "./breez_liquid_sdkFFI.xcframework"),#.binaryTarget(name: "breez_liquid_sdkFFI", url: "https://github.com/breez/breez-liquid-sdk-langs/swift/releases/download/${{ inputs.package-version || '0.0.1' }}/breez_liquid_sdkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#;/.testTarget(name: "BreezLiquidSDKTests", dependencies: \["BreezLiquidSDK"\]),/d' Package.swift > ../../../../../dist/Package.swift
+          cp -r Sources ../../../../../dist
 
       - name: Update Cocoapods definitions
         working-directory: dist

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -120,6 +120,7 @@ jobs:
         if: ${{ inputs.publish }}
         uses: ncipollo/release-action@v1
         with:
+          repo: breez/breez-liquid-sdk-swift
           artifacts: "build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework.zip"
           tag: ${{ inputs.package-version || '0.0.1' }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -80,9 +80,7 @@ jobs:
           cp swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64/breez_liquid_sdkFFI.framework/Headers
           cp swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_liquid_sdkFFI.framework/Headers
           cp swift/breez_liquid_sdkFFI.h build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/macos-arm64_x86_64/breez_liquid_sdkFFI.framework/Headers
-          mkdir -p build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
           cp aarch64-apple-ios/libbreez_liquid_sdk_bindings.a build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
-          mkdir -p build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
           cp ios-universal-sim/libbreez_liquid_sdk_bindings.a build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
           cp darwin-universal/libbreez_liquid_sdk_bindings.a build/lib/bindings/langs/swift/breez_liquid_sdkFFI.xcframework/macos-arm64_x86_64/breez_liquid_sdkFFI.framework/breez_liquid_sdkFFI
 

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+  - ./lib/bindings/langs/android/buildForJitpack.sh

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -551,8 +551,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "uniffi 0.27.1",
- "uniffi-kotlin-multiplatform",
  "uniffi_bindgen 0.25.3",
+ "uniffi_bindgen_kotlin_multiplatform",
 ]
 
 [[package]]
@@ -3069,23 +3069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi-kotlin-multiplatform"
-version = "0.1.0"
-source = "git+https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings?rev=55d51f3abf9819b32bd81756053dcfc10f8d5522#55d51f3abf9819b32bd81756053dcfc10f8d5522"
-dependencies = [
- "anyhow",
- "askama 0.12.1",
- "camino",
- "clap 4.5.4",
- "heck 0.4.1",
- "include_dir",
- "paste",
- "serde",
- "toml",
- "uniffi_bindgen 0.25.3",
-]
-
-[[package]]
 name = "uniffi_bindgen"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3138,23 @@ dependencies = [
  "uniffi_meta 0.27.1",
  "uniffi_testing 0.27.1",
  "uniffi_udl 0.27.1",
+]
+
+[[package]]
+name = "uniffi_bindgen_kotlin_multiplatform"
+version = "0.1.0"
+source = "git+https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings?rev=e8e3a88df5b657787c1198425c16008232b26548#e8e3a88df5b657787c1198425c16008232b26548"
+dependencies = [
+ "anyhow",
+ "askama 0.12.1",
+ "camino",
+ "clap 4.5.4",
+ "heck 0.4.1",
+ "include_dir",
+ "paste",
+ "serde",
+ "toml",
+ "uniffi_bindgen 0.25.3",
 ]
 
 [[package]]

--- a/lib/bindings/Cargo.toml
+++ b/lib/bindings/Cargo.toml
@@ -18,7 +18,7 @@ log = { workspace = true }
 uniffi = { workspace = true, features = [ "bindgen-tests", "cli" ] }
 # Bindgen used by KMP, version has to match the one supported by KMP
 uniffi_bindgen = "0.25.2"
-uniffi-kotlin-multiplatform = { git = "https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings", rev = "55d51f3abf9819b32bd81756053dcfc10f8d5522" }
+uniffi_bindgen_kotlin_multiplatform = { git = "https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings", rev = "e8e3a88df5b657787c1198425c16008232b26548" }
 camino = "1.1.1"
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["rt"] }

--- a/lib/bindings/uniffi-bindgen.rs
+++ b/lib/bindings/uniffi-bindgen.rs
@@ -1,5 +1,5 @@
 use camino::Utf8Path;
-use uniffi_kotlin_multiplatform::KotlinBindingGenerator;
+use uniffi_bindgen_kotlin_multiplatform::KotlinBindingGenerator;
 
 fn main() {
     uniffi::uniffi_bindgen_main();

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -36,10 +36,6 @@ tokio = { version = "1", features = ["rt", "macros"] }
 url = "2.5.0"
 futures-util = { version = "0.3.28", default-features = false, features = ["sink", "std"] }
 
-# Pin these versions to fix iOS build issues
-security-framework = "=2.10.0"
-security-framework-sys = "=2.10.0"
-
 [dev-dependencies]
 tempdir = "0.3.7"
 uuid = { version = "1.8.0", features = ["v4"] }
@@ -47,3 +43,8 @@ uuid = { version = "1.8.0", features = ["v4"] }
 [build-dependencies]
 anyhow = { version = "1.0.79", features = ["backtrace"] }
 glob = "0.3.1"
+
+# Pin these versions to fix iOS build issues
+[target.'cfg(target_os = "ios")'.build-dependencies]
+security-framework = "=2.10.0"
+security-framework-sys = "=2.10.0"

--- a/packages/react-native/example/android/app/build.gradle
+++ b/packages/react-native/example/android/app/build.gradle
@@ -281,6 +281,9 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    
+    implementation 'androidx.core:core-ktx:1.3.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlin_version}"
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'

--- a/packages/react-native/example/android/build.gradle
+++ b/packages/react-native/example/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 34
         targetSdkVersion = 34
+        kotlin_version = "1.8.0"
 
         ndkVersion = "25.1.8937393"
     }
@@ -17,6 +18,7 @@ buildscript {
         classpath('com.android.tools.build:gradle:7.4.2')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
This PR fixes:
- The working directories used during publishing
- Bumps uniffi_bindgen_kotlin_multiplatform to fix issues with generated callback interfaces (Logger, EventListener)
- Creating the Swift release
- The MVN url pre-check for jitpack
- Building the RN android example app