### PR TITLE
Fix windows build

### DIFF
--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -36,10 +36,6 @@ tokio = { version = "1", features = ["rt", "macros"] }
 url = "2.5.0"
 futures-util = { version = "0.3.28", default-features = false, features = ["sink", "std"] }
 
-# Pin these versions to fix iOS build issues
-security-framework = "=2.10.0"
-security-framework-sys = "=2.10.0"
-
 [dev-dependencies]
 tempdir = "0.3.7"
 uuid = { version = "1.8.0", features = ["v4"] }
@@ -47,3 +43,8 @@ uuid = { version = "1.8.0", features = ["v4"] }
 [build-dependencies]
 anyhow = { version = "1.0.79", features = ["backtrace"] }
 glob = "0.3.1"
+
+# Pin these versions to fix iOS build issues
+[target.'cfg(target_os = "ios")'.build-dependencies]
+security-framework = "=2.10.0"
+security-framework-sys = "=2.10.0"


### PR DESCRIPTION
The pinning of `security-framework` was causing a failure to build of windows. As the pinning is only needed for iOS builds, we only need to pin when the target_os is iOS.

```
error[E0433]: failed to resolve: could not find `unix` in `os`
  --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\core-foundation-0.9.4\src\filedescriptor.rs:19:14
   |
19 | use std::os::unix::io::{AsRawFd, RawFd};
   |              ^^^^ could not find `unix` in `os`
   |
note: found an item that was configured out
  --> /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6\library\std\src\os\mod.rs:26:9
note: found an item that was configured out
  --> /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6\library\std\src\os\mod.rs:64:9

error[E0432]: unresolved import `libc::PATH_MAX`
  --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\core-foundation-0.9.4\src\url.rs:22:28
   |
22 | use libc::{c_char, strlen, PATH_MAX};
   |                            ^^^^^^^^ no `PATH_MAX` in the root

   Compiling security-framework-sys v2.10.0
```