### PR TITLE
Send swap handler

### DIFF
--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod logger;
 pub mod model;
 pub mod persist;
 pub mod sdk;
+pub(crate) mod send_swap;
 pub(crate) mod swapper;
 pub(crate) mod utils;
 pub(crate) mod wallet;

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -4,17 +4,12 @@ use boltz_client::lightning_invoice::Bolt11InvoiceDescription;
 use boltz_client::swaps::boltzv2;
 use boltz_client::ToHex;
 use boltz_client::{
-    swaps::{
-        boltz::{RevSwapStates, SubSwapStates},
-        boltzv2::*,
-    },
+    swaps::{boltz::RevSwapStates, boltzv2::*},
     util::secrets::Preimage,
     Amount, Bolt11Invoice,
 };
 use log::{debug, error, info, warn};
-use lwk_wollet::bitcoin::Witness;
-use lwk_wollet::hashes::{sha256, Hash};
-use lwk_wollet::{elements::LockTime, BlockchainBackend, ElementsNetwork};
+use lwk_wollet::{elements::LockTime, ElementsNetwork};
 use std::time::Instant;
 use std::{
     fs,
@@ -28,6 +23,7 @@ use tokio::time::MissedTickBehavior;
 
 use crate::error::LiquidSdkError;
 use crate::model::PaymentState::*;
+use crate::send_swap::SendSwapStateHandler;
 use crate::swapper::{BoltzSwapper, ReconnectHandler, Swapper, SwapperStatusStream};
 use crate::wallet::{LiquidOnchainWallet, OnchainWallet};
 use crate::{
@@ -172,6 +168,12 @@ impl LiquidSdk {
         tokio::spawn(async move {
             let mut shutdown_receiver = cloned.shutdown_receiver.clone();
             let mut updates_stream = cloned.status_stream.subscribe_swap_updates();
+            let send_swap_state_handler = SendSwapStateHandler::new(
+                cloned.config.clone(),
+                cloned.onchain_wallet.clone(),
+                cloned.persister.clone(),
+                cloned.swapper.clone(),
+            );
             loop {
                 tokio::select! {
                     update = updates_stream.recv() => match update {
@@ -179,7 +181,7 @@ impl LiquidSdk {
                             let _ = cloned.sync().await;
                             match cloned.persister.fetch_send_swap_by_id(&id) {
                                 Ok(Some(_)) => {
-                                    match cloned.try_handle_send_swap_boltz_status(&status, &id).await {
+                                    match send_swap_state_handler.on_new_status(&status, &id).await {
                                         Ok(_) => info!("Succesfully handled Send Swap {id} update"),
                                         Err(e) => error!("Failed to handle Send Swap {id} update: {e}")
                                     }
@@ -250,7 +252,14 @@ impl LiquidSdk {
                 let id = &send_swap.id;
                 let refund_tx_id = self.try_refund(send_swap).await?;
                 info!("Broadcast refund tx for Send Swap {id}. Tx id: {refund_tx_id}");
-                self.try_handle_send_swap_update(id, Pending, None, None, Some(&refund_tx_id))
+                let send_swap_state_handler = SendSwapStateHandler::new(
+                    self.config.clone(),
+                    self.onchain_wallet.clone(),
+                    self.persister.clone(),
+                    self.swapper.clone(),
+                );
+                send_swap_state_handler
+                    .update_swap_info(id, Pending, None, None, Some(&refund_tx_id))
                     .await?;
             }
         }
@@ -326,37 +335,6 @@ impl LiquidSdk {
         self.persister
             .try_handle_receive_swap_update(swap_id, to_state, claim_tx_id)?;
 
-        Ok(self.emit_payment_updated(payment_id).await?)
-    }
-
-    /// Transitions a Send swap to a new state
-    pub(crate) async fn try_handle_send_swap_update(
-        &self,
-        swap_id: &str,
-        to_state: PaymentState,
-        preimage: Option<&str>,
-        lockup_tx_id: Option<&str>,
-        refund_tx_id: Option<&str>,
-    ) -> Result<(), PaymentError> {
-        info!("Transitioning Send swap {swap_id} to {to_state:?} (lockup_tx_id = {lockup_tx_id:?}, refund_tx_id = {refund_tx_id:?})");
-
-        let swap: SendSwap = self
-            .persister
-            .fetch_send_swap_by_id(swap_id)
-            .map_err(|_| PaymentError::PersistError)?
-            .ok_or(PaymentError::Generic {
-                err: format!("Send Swap not found {swap_id}"),
-            })?;
-        let payment_id = lockup_tx_id.map(|c| c.to_string()).or(swap.lockup_tx_id);
-
-        Self::validate_state_transition(swap.state, to_state)?;
-        self.persister.try_handle_send_swap_update(
-            swap_id,
-            to_state,
-            preimage,
-            lockup_tx_id,
-            refund_tx_id,
-        )?;
         Ok(self.emit_payment_updated(payment_id).await?)
     }
 
@@ -509,145 +487,6 @@ impl LiquidSdk {
         }
     }
 
-    /// Handles status updates from Boltz for Send swaps
-    pub(crate) async fn try_handle_send_swap_boltz_status(
-        &self,
-        swap_state: &str,
-        id: &str,
-    ) -> Result<()> {
-        let swap = self
-            .persister
-            .fetch_send_swap_by_id(id)?
-            .ok_or(anyhow!("No ongoing Send Swap found for ID {id}"))?;
-
-        info!("Handling Send Swap transition to {swap_state:?} for swap {id}");
-
-        // See https://docs.boltz.exchange/v/api/lifecycle#normal-submarine-swaps
-        match SubSwapStates::from_str(swap_state) {
-            // Boltz has locked the HTLC, we proceed with locking up the funds
-            Ok(SubSwapStates::InvoiceSet) => {
-                match (swap.state, swap.lockup_tx_id.clone()) {
-                    (PaymentState::Created, None) | (PaymentState::TimedOut, None) => {
-                        let create_response = swap.get_boltz_create_response()?;
-                        let lockup_tx_id = self.lockup_funds(id, &create_response).await?;
-
-                        // We insert a pseudo-lockup-tx in case LWK fails to pick up the new mempool tx for a while
-                        // This makes the tx known to the SDK (get_info, list_payments) instantly
-                        self.persister.insert_or_update_payment(PaymentTxData {
-                            tx_id: lockup_tx_id.clone(),
-                            timestamp: None,
-                            amount_sat: swap.payer_amount_sat,
-                            payment_type: PaymentType::Send,
-                            is_confirmed: false,
-                        })?;
-
-                        self.try_handle_send_swap_update(
-                            id,
-                            Pending,
-                            None,
-                            Some(&lockup_tx_id),
-                            None,
-                        )
-                        .await?;
-                    }
-                    (_, Some(lockup_tx_id)) => warn!(
-                        "Lockup tx for Send Swap {id} was already broadcast: txid {lockup_tx_id}"
-                    ),
-                    (state, _) => {
-                        debug!("Send Swap {id} is in an invalid state for {swap_state}: {state:?}")
-                    }
-                }
-                Ok(())
-            }
-
-            // Boltz has detected the lockup in the mempool, we can speed up
-            // the claim by doing so cooperatively
-            Ok(SubSwapStates::TransactionClaimPending) => {
-                self.cooperate_send_swap_claim(&swap).await.map_err(|e| {
-                    error!("Could not cooperate Send Swap {id} claim: {e}");
-                    anyhow!("Could not post claim details. Err: {e:?}")
-                })?;
-
-                Ok(())
-            }
-
-            // Boltz announced they successfully broadcast the (cooperative or non-cooperative) claim tx
-            Ok(SubSwapStates::TransactionClaimed) => {
-                debug!("Send Swap {id} has been claimed");
-
-                match swap.preimage {
-                    Some(_) => {
-                        debug!("The claim tx was a key path spend (cooperative claim)");
-                        // Preimage was already validated and stored, PaymentSucceeded event emitted,
-                        // when the cooperative claim was handled.
-                    }
-                    None => {
-                        debug!("The claim tx was a script path spend (non-cooperative claim)");
-                        let preimage = self.get_preimage_from_script_path_claim_spend(&swap)?;
-                        self.validate_send_swap_preimage(id, &swap.invoice, &preimage)
-                            .await?;
-                        self.try_handle_send_swap_update(id, Complete, Some(&preimage), None, None)
-                            .await?;
-                    }
-                }
-
-                Ok(())
-            }
-
-            // If swap state is unrecoverable, either:
-            // 1. Boltz failed to pay
-            // 2. The swap has expired (>24h)
-            // 3. Lockup failed (we sent too little funds)
-            // We initiate a cooperative refund, and then fallback to a regular one
-            Ok(
-                SubSwapStates::TransactionLockupFailed
-                | SubSwapStates::InvoiceFailedToPay
-                | SubSwapStates::SwapExpired,
-            ) => {
-                match swap.lockup_tx_id {
-                    Some(_) => match swap.refund_tx_id {
-                        Some(refund_tx_id) => warn!(
-                            "Refund tx for Send Swap {id} was already broadcast: txid {refund_tx_id}"
-                        ),
-                        None => {
-                            warn!("Send Swap {id} is in an unrecoverable state: {swap_state:?}, and lockup tx has been broadcast. Attempting refund.");
-
-                            let refund_tx_id = self.try_refund(&swap).await?;
-                            info!("Broadcast refund tx for Send Swap {id}. Tx id: {refund_tx_id}");
-                            self.try_handle_send_swap_update(
-                                id,
-                                Pending,
-                                None,
-                                None,
-                                Some(&refund_tx_id),
-                            )
-                            .await?;
-                        }
-                    },
-                    // Do not attempt broadcasting a refund if lockup tx was never sent and swap is
-                    // unrecoverable. We resolve the payment as failed.
-                    None => {
-                        warn!("Send Swap {id} is in an unrecoverable state: {swap_state:?}, and lockup tx has never been broadcast. Resolving payment as failed.");
-                        self.try_handle_send_swap_update(id, Failed, None, None, None)
-                            .await?;
-                    }
-
-                }
-
-                Ok(())
-            }
-
-            Ok(_) => {
-                debug!("Unhandled state for Send Swap {id}: {swap_state}");
-                Ok(())
-            }
-
-            _ => Err(anyhow!(
-                "Invalid SubSwapState for Send Swap {id}: {swap_state}"
-            )),
-        }
-    }
-
     pub async fn get_info(&self, req: GetInfoRequest) -> Result<GetInfoResponse> {
         self.ensure_is_started().await?;
         debug!(
@@ -777,17 +616,6 @@ impl LiquidSdk {
         })
     }
 
-    fn verify_payment_hash(preimage: &str, invoice: &str) -> Result<(), PaymentError> {
-        let preimage = Preimage::from_str(preimage)?;
-        let preimage_hash = preimage.sha256.to_string();
-        let invoice = Bolt11Invoice::from_str(invoice).map_err(|_| PaymentError::InvalidInvoice)?;
-        let invoice_payment_hash = invoice.payment_hash();
-
-        (invoice_payment_hash.to_string() == preimage_hash)
-            .then_some(())
-            .ok_or(PaymentError::InvalidPreimage)
-    }
-
     async fn try_refund_non_cooperative(
         &self,
         swap: &SendSwap,
@@ -831,67 +659,6 @@ impl LiquidSdk {
                     .await
             }
         }
-    }
-
-    /// Check if the provided preimage matches our invoice. If so, mark the Send payment as [Complete].
-    async fn validate_send_swap_preimage(
-        &self,
-        swap_id: &str,
-        invoice: &str,
-        preimage: &str,
-    ) -> Result<(), PaymentError> {
-        Self::verify_payment_hash(preimage, invoice)?;
-        info!("Preimage is valid for Send Swap {swap_id}");
-        Ok(())
-    }
-
-    /// Interact with Boltz to assist in them doing a cooperative claim
-    async fn cooperate_send_swap_claim(&self, send_swap: &SendSwap) -> Result<(), PaymentError> {
-        debug!(
-            "Claim is pending for Send Swap {}. Initiating cooperative claim",
-            &send_swap.id
-        );
-        let output_address = self.onchain_wallet.next_unused_address().await?.to_string();
-        let claim_tx_details = self.swapper.get_claim_tx_details(send_swap)?;
-        self.try_handle_send_swap_update(
-            &send_swap.id,
-            Complete,
-            Some(&claim_tx_details.preimage),
-            None,
-            None,
-        )
-        .await?;
-        self.swapper
-            .claim_send_swap_cooperative(send_swap, claim_tx_details, &output_address)?;
-        Ok(())
-    }
-
-    async fn lockup_funds(
-        &self,
-        swap_id: &str,
-        create_response: &CreateSubmarineResponse,
-    ) -> Result<String, PaymentError> {
-        debug!(
-            "Initiated Send Swap: send {} sats to liquid address {}",
-            create_response.expected_amount, create_response.address
-        );
-
-        let lockup_tx = self
-            .onchain_wallet
-            .build_tx(
-                None,
-                &create_response.address,
-                create_response.expected_amount,
-            )
-            .await?;
-
-        let electrum_client = self.config.get_electrum_client()?;
-        let lockup_tx_id = electrum_client.broadcast(&lockup_tx)?.to_string();
-
-        debug!(
-            "Successfully broadcast lockup transaction for Send Swap {swap_id}. Lockup tx id: {lockup_tx_id}"
-        );
-        Ok(lockup_tx_id)
     }
 
     /// Creates, initiates and starts monitoring the progress of a Send Payment.
@@ -976,6 +743,12 @@ impl LiquidSdk {
 
         let mut events_stream = self.event_manager.subscribe();
         let mut maybe_payment: Option<Payment> = None;
+        let send_swap_state_handler = SendSwapStateHandler::new(
+            self.config.clone(),
+            self.onchain_wallet.clone(),
+            self.persister.clone(),
+            self.swapper.clone(),
+        );
 
         loop {
             tokio::select! {
@@ -983,7 +756,7 @@ impl LiquidSdk {
                     Some(payment) => return Ok(payment),
                     None => {
                         debug!("Timeout occured without payment, set swap to timed out");
-                        self.try_handle_send_swap_update(&swap_id, TimedOut, None, None, None).await?;
+                        send_swap_state_handler.update_swap_info(&swap_id, TimedOut, None, None, None).await?;
                         return Err(PaymentError::PaymentTimeout)
                     },
                 },
@@ -1161,6 +934,12 @@ impl LiquidSdk {
         let pending_send_swaps_by_refund_tx_id =
             self.persister.list_pending_send_swaps_by_refund_tx_id()?;
 
+        let send_swap_state_handler = SendSwapStateHandler::new(
+            self.config.clone(),
+            self.onchain_wallet.clone(),
+            self.persister.clone(),
+            self.swapper.clone(),
+        );
         for tx in self.onchain_wallet.transactions().await? {
             let tx_id = tx.txid.to_string();
             let is_tx_confirmed = tx.height.is_some();
@@ -1173,7 +952,8 @@ impl LiquidSdk {
                         .await?;
                 }
                 if let Some(swap) = pending_send_swaps_by_refund_tx_id.get(&tx_id) {
-                    self.try_handle_send_swap_update(&swap.id, Failed, None, None, None)
+                    send_swap_state_handler
+                        .update_swap_info(&swap.id, Failed, None, None, None)
                         .await?;
                 }
             }
@@ -1191,72 +971,6 @@ impl LiquidSdk {
         }
 
         Ok(())
-    }
-
-    fn get_preimage_from_script_path_claim_spend(
-        &self,
-        swap: &SendSwap,
-    ) -> Result<String, PaymentError> {
-        info!("Retrieving preimage from non-cooperative claim tx");
-
-        let id = &swap.id;
-        let electrum_client = self.config.get_electrum_client()?;
-        let swap_script = swap.get_swap_script()?;
-        let swap_script_pk = swap_script
-            .to_address(self.config.network.into())?
-            .script_pubkey();
-        debug!("Found Send Swap swap_script_pk: {swap_script_pk:?}");
-
-        // Get tx history of the swap script (lockup address)
-        let history: Vec<_> = electrum_client
-            .get_scripts_history(&[&swap_script_pk])?
-            .into_iter()
-            .flatten()
-            .collect();
-
-        // We expect at most 2 txs: lockup and maybe the claim
-        ensure_sdk!(
-            history.len() <= 2,
-            PaymentError::Generic {
-                err: "Lockup address history for Send Swap {id} has more than 2 txs".to_string()
-            }
-        );
-
-        match history.get(1) {
-            None => Err(PaymentError::Generic {
-                err: format!("Send Swap {id} has no claim tx"),
-            }),
-            Some(claim_tx_entry) => {
-                let claim_tx_id = claim_tx_entry.txid;
-                debug!("Send Swap {id} has claim tx {claim_tx_id}");
-
-                let claim_tx = electrum_client
-                    .get_transactions(&[claim_tx_id])
-                    .map_err(|e| anyhow!("Failed to fetch claim tx {claim_tx_id}: {e}"))?
-                    .first()
-                    .cloned()
-                    .ok_or_else(|| anyhow!("Fetching claim tx returned an empty list"))?;
-
-                let input = claim_tx
-                    .input
-                    .first()
-                    .ok_or_else(|| anyhow!("Found no input for claim tx"))?;
-
-                let script_witness_bytes = input.clone().witness.script_witness;
-                info!("Found Send Swap {id} claim tx witness: {script_witness_bytes:?}");
-                let script_witness = Witness::from(script_witness_bytes);
-
-                let preimage_bytes = script_witness
-                    .nth(1)
-                    .ok_or_else(|| anyhow!("Claim tx witness has no preimage"))?;
-                let preimage = sha256::Hash::from_slice(preimage_bytes)
-                    .map_err(|e| anyhow!("Claim tx witness has invalid preimage: {e}"))?;
-                let preimage_hex = preimage.to_hex();
-                debug!("Found Send Swap {id} claim tx preimage: {preimage_hex}");
-
-                Ok(preimage_hex)
-            }
-        }
     }
 
     /// Lists the SDK payments. The payments are determined based on onchain transactions and swaps.

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -1,0 +1,416 @@
+use crate::model::PaymentState::{Complete, Created, Failed, Pending, TimedOut};
+use crate::model::{Config, SendSwap};
+use crate::swapper::Swapper;
+use crate::wallet::OnchainWallet;
+use crate::{ensure_sdk, get_invoice_amount};
+use crate::{
+    error::PaymentError,
+    model::{PaymentState, PaymentTxData, PaymentType},
+    persist::Persister,
+};
+use anyhow::{anyhow, Result};
+use boltz_client::swaps::{boltz::SubSwapStates, boltzv2::CreateSubmarineResponse};
+use boltz_client::util::secrets::Preimage;
+use boltz_client::{Amount, Bolt11Invoice, ToHex};
+use log::{debug, error, info, warn};
+use lwk_wollet::bitcoin::Witness;
+use lwk_wollet::hashes::{sha256, Hash};
+use lwk_wollet::BlockchainBackend;
+use std::{str::FromStr, sync::Arc};
+use tokio::sync::broadcast;
+
+pub(crate) struct SendSwapStateHandler {
+    config: Config,
+    onchain_wallet: Arc<dyn OnchainWallet>,
+    persister: Arc<Persister>,
+    swapper: Arc<dyn Swapper>,
+    subscription_notifier: broadcast::Sender<String>,
+}
+
+impl SendSwapStateHandler {
+    pub(crate) fn new(
+        config: Config,
+        onchain_wallet: Arc<dyn OnchainWallet>,
+        persister: Arc<Persister>,
+        swapper: Arc<dyn Swapper>,
+    ) -> Self {
+        let (subscription_notifier, _) = broadcast::channel::<String>(30);
+        Self {
+            config,
+            onchain_wallet,
+            persister,
+            swapper,
+            subscription_notifier,
+        }
+    }
+
+    fn subscribe_swap_updates(&self) -> broadcast::Receiver<String> {
+        self.subscription_notifier.subscribe()
+    }
+
+    /// Handles status updates from Boltz for Send swaps
+    pub(crate) async fn on_new_status(&self, swap_state: &str, id: &str) -> Result<()> {
+        let swap = self
+            .persister
+            .fetch_send_swap_by_id(id)?
+            .ok_or(anyhow!("No ongoing Send Swap found for ID {id}"))?;
+
+        info!("Handling Send Swap transition to {swap_state:?} for swap {id}");
+
+        // See https://docs.boltz.exchange/v/api/lifecycle#normal-submarine-swaps
+        match SubSwapStates::from_str(swap_state) {
+            // Boltz has locked the HTLC, we proceed with locking up the funds
+            Ok(SubSwapStates::InvoiceSet) => {
+                match (swap.state, swap.lockup_tx_id.clone()) {
+                    (PaymentState::Created, None) | (PaymentState::TimedOut, None) => {
+                        let create_response = swap.get_boltz_create_response()?;
+                        let lockup_tx_id = self.lockup_funds(id, &create_response).await?;
+
+                        // We insert a pseudo-lockup-tx in case LWK fails to pick up the new mempool tx for a while
+                        // This makes the tx known to the SDK (get_info, list_payments) instantly
+                        self.persister.insert_or_update_payment(PaymentTxData {
+                            tx_id: lockup_tx_id.clone(),
+                            timestamp: None,
+                            amount_sat: swap.payer_amount_sat,
+                            payment_type: PaymentType::Send,
+                            is_confirmed: false,
+                        })?;
+
+                        self.update_swap_info(id, Pending, None, Some(&lockup_tx_id), None)
+                            .await?;
+                    }
+                    (_, Some(lockup_tx_id)) => {
+                        warn!("Lockup tx for Send Swap {id} was already broadcast: txid {lockup_tx_id}")
+                    }
+                    (state, _) => {
+                        debug!("Send Swap {id} is in an invalid state for {swap_state}: {state:?}")
+                    }
+                }
+                Ok(())
+            }
+
+            // Boltz has detected the lockup in the mempool, we can speed up
+            // the claim by doing so cooperatively
+            Ok(SubSwapStates::TransactionClaimPending) => {
+                self.cooperate_claim(&swap).await.map_err(|e| {
+                    error!("Could not cooperate Send Swap {id} claim: {e}");
+                    anyhow!("Could not post claim details. Err: {e:?}")
+                })?;
+
+                Ok(())
+            }
+
+            // Boltz announced they successfully broadcast the (cooperative or non-cooperative) claim tx
+            Ok(SubSwapStates::TransactionClaimed) => {
+                debug!("Send Swap {id} has been claimed");
+
+                match swap.preimage {
+                    Some(_) => {
+                        debug!("The claim tx was a key path spend (cooperative claim)");
+                        // Preimage was already validated and stored, PaymentSucceeded event emitted,
+                        // when the cooperative claim was handled.
+                    }
+                    None => {
+                        debug!("The claim tx was a script path spend (non-cooperative claim)");
+                        let preimage = self.get_preimage_from_script_path_claim_spend(&swap)?;
+                        self.validate_send_swap_preimage(id, &swap.invoice, &preimage)
+                            .await?;
+                        self.update_swap_info(id, Complete, Some(&preimage), None, None)
+                            .await?;
+                    }
+                }
+
+                Ok(())
+            }
+
+            // If swap state is unrecoverable, either:
+            // 1. Boltz failed to pay
+            // 2. The swap has expired (>24h)
+            // 3. Lockup failed (we sent too little funds)
+            // We initiate a cooperative refund, and then fallback to a regular one
+            Ok(
+                SubSwapStates::TransactionLockupFailed
+                | SubSwapStates::InvoiceFailedToPay
+                | SubSwapStates::SwapExpired,
+            ) => {
+                match swap.lockup_tx_id {
+                    Some(_) => match swap.refund_tx_id {
+                        Some(refund_tx_id) => warn!(
+                        "Refund tx for Send Swap {id} was already broadcast: txid {refund_tx_id}"
+                    ),
+                        None => {
+                            warn!("Send Swap {id} is in an unrecoverable state: {swap_state:?}, and lockup tx has been broadcast. Attempting refund.");
+
+                            let refund_tx_id = self.refund(&swap).await?;
+                            info!("Broadcast refund tx for Send Swap {id}. Tx id: {refund_tx_id}");
+                            self.update_swap_info(id, Pending, None, None, Some(&refund_tx_id))
+                                .await?;
+                        }
+                    },
+                    // Do not attempt broadcasting a refund if lockup tx was never sent and swap is
+                    // unrecoverable. We resolve the payment as failed.
+                    None => {
+                        warn!("Send Swap {id} is in an unrecoverable state: {swap_state:?}, and lockup tx has never been broadcast. Resolving payment as failed.");
+                        self.update_swap_info(id, Failed, None, None, None).await?;
+                    }
+                }
+
+                Ok(())
+            }
+
+            Ok(_) => {
+                debug!("Unhandled state for Send Swap {id}: {swap_state}");
+                Ok(())
+            }
+
+            _ => Err(anyhow!(
+                "Invalid SubSwapState for Send Swap {id}: {swap_state}"
+            )),
+        }
+    }
+
+    async fn lockup_funds(
+        &self,
+        swap_id: &str,
+        create_response: &CreateSubmarineResponse,
+    ) -> Result<String, PaymentError> {
+        debug!(
+            "Initiated Send Swap: send {} sats to liquid address {}",
+            create_response.expected_amount, create_response.address
+        );
+
+        let lockup_tx = self
+            .onchain_wallet
+            .build_tx(
+                None,
+                &create_response.address,
+                create_response.expected_amount,
+            )
+            .await?;
+
+        let electrum_client = self.config.get_electrum_client()?;
+        let lockup_tx_id = electrum_client.broadcast(&lockup_tx)?.to_string();
+
+        debug!(
+          "Successfully broadcast lockup transaction for Send Swap {swap_id}. Lockup tx id: {lockup_tx_id}"
+      );
+        Ok(lockup_tx_id)
+    }
+
+    /// Transitions a Send swap to a new state
+    pub(crate) async fn update_swap_info(
+        &self,
+        swap_id: &str,
+        to_state: PaymentState,
+        preimage: Option<&str>,
+        lockup_tx_id: Option<&str>,
+        refund_tx_id: Option<&str>,
+    ) -> Result<(), PaymentError> {
+        info!("Transitioning Send swap {swap_id} to {to_state:?} (lockup_tx_id = {lockup_tx_id:?}, refund_tx_id = {refund_tx_id:?})");
+
+        let swap: SendSwap = self
+            .persister
+            .fetch_send_swap_by_id(swap_id)
+            .map_err(|_| PaymentError::PersistError)?
+            .ok_or(PaymentError::Generic {
+                err: format!("Send Swap not found {swap_id}"),
+            })?;
+        let payment_id = lockup_tx_id.map(|c| c.to_string()).or(swap.lockup_tx_id);
+
+        Self::validate_state_transition(swap.state, to_state)?;
+        self.persister.try_handle_send_swap_update(
+            swap_id,
+            to_state,
+            preimage,
+            lockup_tx_id,
+            refund_tx_id,
+        )?;
+        if let Some(payment_id) = payment_id {
+            let _ = self.subscription_notifier.send(payment_id);
+        }
+        Ok(())
+    }
+
+    async fn cooperate_claim(&self, send_swap: &SendSwap) -> Result<(), PaymentError> {
+        debug!(
+            "Claim is pending for Send Swap {}. Initiating cooperative claim",
+            &send_swap.id
+        );
+        let output_address = self.onchain_wallet.next_unused_address().await?.to_string();
+        let claim_tx_details = self.swapper.get_claim_tx_details(send_swap)?;
+        self.update_swap_info(
+            &send_swap.id,
+            Complete,
+            Some(&claim_tx_details.preimage),
+            None,
+            None,
+        )
+        .await?;
+        self.swapper
+            .claim_send_swap_cooperative(send_swap, claim_tx_details, &output_address)?;
+        Ok(())
+    }
+
+    fn get_preimage_from_script_path_claim_spend(
+        &self,
+        swap: &SendSwap,
+    ) -> Result<String, PaymentError> {
+        info!("Retrieving preimage from non-cooperative claim tx");
+
+        let id = &swap.id;
+        let electrum_client = self.config.get_electrum_client()?;
+        let swap_script = swap.get_swap_script()?;
+        let swap_script_pk = swap_script
+            .to_address(self.config.network.into())?
+            .script_pubkey();
+        debug!("Found Send Swap swap_script_pk: {swap_script_pk:?}");
+
+        // Get tx history of the swap script (lockup address)
+        let history: Vec<_> = electrum_client
+            .get_scripts_history(&[&swap_script_pk])?
+            .into_iter()
+            .flatten()
+            .collect();
+
+        // We expect at most 2 txs: lockup and maybe the claim
+        ensure_sdk!(
+            history.len() <= 2,
+            PaymentError::Generic {
+                err: "Lockup address history for Send Swap {id} has more than 2 txs".to_string()
+            }
+        );
+
+        match history.get(1) {
+            None => Err(PaymentError::Generic {
+                err: format!("Send Swap {id} has no claim tx"),
+            }),
+            Some(claim_tx_entry) => {
+                let claim_tx_id = claim_tx_entry.txid;
+                debug!("Send Swap {id} has claim tx {claim_tx_id}");
+
+                let claim_tx = electrum_client
+                    .get_transactions(&[claim_tx_id])
+                    .map_err(|e| anyhow!("Failed to fetch claim tx {claim_tx_id}: {e}"))?
+                    .first()
+                    .cloned()
+                    .ok_or_else(|| anyhow!("Fetching claim tx returned an empty list"))?;
+
+                let input = claim_tx
+                    .input
+                    .first()
+                    .ok_or_else(|| anyhow!("Found no input for claim tx"))?;
+
+                let script_witness_bytes = input.clone().witness.script_witness;
+                info!("Found Send Swap {id} claim tx witness: {script_witness_bytes:?}");
+                let script_witness = Witness::from(script_witness_bytes);
+
+                let preimage_bytes = script_witness
+                    .nth(1)
+                    .ok_or_else(|| anyhow!("Claim tx witness has no preimage"))?;
+                let preimage = sha256::Hash::from_slice(preimage_bytes)
+                    .map_err(|e| anyhow!("Claim tx witness has invalid preimage: {e}"))?;
+                let preimage_hex = preimage.to_hex();
+                debug!("Found Send Swap {id} claim tx preimage: {preimage_hex}");
+
+                Ok(preimage_hex)
+            }
+        }
+    }
+
+    async fn validate_send_swap_preimage(
+        &self,
+        swap_id: &str,
+        invoice: &str,
+        preimage: &str,
+    ) -> Result<(), PaymentError> {
+        Self::verify_payment_hash(preimage, invoice)?;
+        info!("Preimage is valid for Send Swap {swap_id}");
+        Ok(())
+    }
+
+    async fn refund(&self, swap: &SendSwap) -> Result<String, PaymentError> {
+        let amount_sat = get_invoice_amount!(swap.invoice);
+        let broadcast_fees_sat = Amount::from_sat(
+            self.onchain_wallet
+                .get_broadcast_fee_estimation(amount_sat)
+                .await?,
+        );
+
+        let output_address = self.onchain_wallet.next_unused_address().await?.to_string();
+        let refund_res =
+            self.swapper
+                .refund_send_swap_cooperative(swap, &output_address, broadcast_fees_sat);
+        match refund_res {
+            Ok(res) => Ok(res),
+            Err(e) => {
+                warn!("Cooperative refund failed: {:?}", e);
+                self.refund_non_cooperative(swap, broadcast_fees_sat).await
+            }
+        }
+    }
+
+    fn validate_state_transition(
+        from_state: PaymentState,
+        to_state: PaymentState,
+    ) -> Result<(), PaymentError> {
+        match (from_state, to_state) {
+            (_, Created) => Err(PaymentError::Generic {
+                err: "Cannot transition to Created state".to_string(),
+            }),
+
+            (Created | Pending, Pending) => Ok(()),
+            (Complete | Failed | TimedOut, Pending) => Err(PaymentError::Generic {
+                err: format!("Cannot transition from {from_state:?} to Pending state"),
+            }),
+
+            (Created | Pending, Complete) => Ok(()),
+            (Complete | Failed | TimedOut, Complete) => Err(PaymentError::Generic {
+                err: format!("Cannot transition from {from_state:?} to Complete state"),
+            }),
+
+            (Created, TimedOut) => Ok(()),
+            (_, TimedOut) => Err(PaymentError::Generic {
+                err: format!("Cannot transition from {from_state:?} to TimedOut state"),
+            }),
+
+            (_, Failed) => Ok(()),
+        }
+    }
+
+    fn verify_payment_hash(preimage: &str, invoice: &str) -> Result<(), PaymentError> {
+        let preimage = Preimage::from_str(preimage)?;
+        let preimage_hash = preimage.sha256.to_string();
+        let invoice = Bolt11Invoice::from_str(invoice).map_err(|_| PaymentError::InvalidInvoice)?;
+        let invoice_payment_hash = invoice.payment_hash();
+
+        (invoice_payment_hash.to_string() == preimage_hash)
+            .then_some(())
+            .ok_or(PaymentError::InvalidPreimage)
+    }
+
+    async fn refund_non_cooperative(
+        &self,
+        swap: &SendSwap,
+        broadcast_fees_sat: Amount,
+    ) -> Result<String, PaymentError> {
+        info!(
+            "Initiating non-cooperative refund for Send Swap {}",
+            &swap.id
+        );
+
+        let current_height = self.onchain_wallet.tip().await.height();
+        let output_address = self.onchain_wallet.next_unused_address().await?.to_string();
+        let refund_tx_id = self.swapper.refund_send_swap_non_cooperative(
+            swap,
+            broadcast_fees_sat,
+            &output_address,
+            current_height,
+        )?;
+
+        info!(
+            "Successfully broadcast non-cooperative refund for Send Swap {}, tx: {}",
+            swap.id, refund_tx_id
+        );
+        Ok(refund_tx_id)
+    }
+}

--- a/lib/core/src/wallet.rs
+++ b/lib/core/src/wallet.rs
@@ -42,8 +42,6 @@ pub trait OnchainWallet: Send + Sync {
 
     /// Perform a full scan of the wallet
     async fn full_scan(&self) -> Result<(), PaymentError>;
-
-    async fn get_broadcast_fee_estimation(&self, amount_sat: u64) -> Result<u64, PaymentError>;
 }
 
 pub(crate) struct LiquidOnchainWallet {
@@ -143,22 +141,5 @@ impl OnchainWallet for LiquidOnchainWallet {
             ElectrumClient::new(&ElectrumUrl::new(&self.config.electrum_url, true, true))?;
         lwk_wollet::full_scan_with_electrum_client(&mut wallet, &mut electrum_client)?;
         Ok(())
-    }
-
-    async fn get_broadcast_fee_estimation(&self, amount_sat: u64) -> Result<u64, PaymentError> {
-        // TODO Replace this with own address when LWK supports taproot
-        //  https://github.com/Blockstream/lwk/issues/31
-        let temp_p2tr_addr = match self.config.network {
-          Network::Mainnet => "lq1pqvzxvqhrf54dd4sny4cag7497pe38252qefk46t92frs7us8r80ja9ha8r5me09nn22m4tmdqp5p4wafq3s59cql3v9n45t5trwtxrmxfsyxjnstkctj",
-          Network::Testnet => "tlq1pq0wqu32e2xacxeyps22x8gjre4qk3u6r70pj4r62hzczxeyz8x3yxucrpn79zy28plc4x37aaf33kwt6dz2nn6gtkya6h02mwpzy4eh69zzexq7cf5y5"
-      };
-
-        // Create a throw-away tx similar to the lockup tx, in order to estimate fees
-        Ok(self
-            .build_tx(None, temp_p2tr_addr, amount_sat)
-            .await?
-            .all_fees()
-            .values()
-            .sum())
     }
 }


### PR DESCRIPTION
Here the send swaps state machine handling is extracted out to its own module with dependencies that can be mocked and allow us to write tests.
Also it removes the details from the sdk facade layer.
Once this is reviewed and merged, next in the line is the receive swaps handler.