### PR TITLE
[Flutter] Create reference implementation for Liquid SDK connection manager, event & log stream handler

### DIFF
--- a/packages/dart/test/breez_liquid_dart_test.dart
+++ b/packages/dart/test/breez_liquid_dart_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('main', () {
     setUpAll(() async {
       await initApi();
-      ConnectRequest connectRequest = ConnectRequest(mnemonic: "", network: Network.liquidTestnet);
+      ConnectRequest connectRequest = ConnectRequest(mnemonic: "", config: defaultConfig(network: Network.testnet));
       sdk = await connect(req: connectRequest);
     });
 

--- a/packages/flutter/example/lib/routes/connect/connect_page.dart
+++ b/packages/flutter/example/lib/routes/connect/connect_page.dart
@@ -3,13 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 import 'package:flutter_breez_liquid_example/routes/connect/restore_page.dart';
 import 'package:flutter_breez_liquid_example/routes/home/home_page.dart';
+import 'package:flutter_breez_liquid_example/services/breez_liquid_sdk.dart';
 import 'package:flutter_breez_liquid_example/services/credentials_manager.dart';
 import 'package:flutter_breez_liquid_example/utils/config.dart';
-import 'package:path_provider/path_provider.dart';
 
 class ConnectPage extends StatefulWidget {
+  final BreezLiquidSDK liquidSDK;
   final CredentialsManager credentialsManager;
-  const ConnectPage({super.key, required this.credentialsManager});
+  const ConnectPage({super.key, required this.liquidSDK, required this.credentialsManager});
 
   @override
   State<ConnectPage> createState() => _ConnectPageState();
@@ -84,7 +85,7 @@ class _ConnectPageState extends State<ConnectPage> {
             context,
             MaterialPageRoute(
               builder: (BuildContext context) => HomePage(
-                liquidSDK: liquidSDK,
+                liquidSDK: widget.liquidSDK,
                 credentialsManager: widget.credentialsManager,
               ),
             ),
@@ -103,6 +104,6 @@ class _ConnectPageState extends State<ConnectPage> {
       config: config,
       mnemonic: mnemonic,
     );
-    return await connect(req: req);
+    return await widget.liquidSDK.connect(req: req);
   }
 }

--- a/packages/flutter/example/lib/routes/home/widgets/bottom_app_bar.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/bottom_app_bar.dart
@@ -49,7 +49,7 @@ class HomePageBottomAppBar extends StatelessWidget {
                   context: context,
                   builder: (context) => ReceivePaymentDialog(
                     liquidSDK: liquidSDK,
-                    paymentsStream: paymentsStream.asBroadcastStream(),
+                    paymentsStream: paymentsStream,
                   ),
                 );
               },

--- a/packages/flutter/example/lib/routes/home/widgets/payment_list/widgets/payment_item.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/payment_list/widgets/payment_item.dart
@@ -62,7 +62,7 @@ class PaymentItem extends StatelessWidget {
             "${item.paymentType == PaymentType.send ? "-" : "+"}${item.amountSat} sats",
             style: Theme.of(context).textTheme.bodyLarge,
           ),
-          if (item.feesSat != null) ...[
+          if (item.feesSat != BigInt.zero) ...[
             Text("FEE: ${item.paymentType == PaymentType.receive ? "-" : ""}${item.feesSat} sats"),
           ]
         ],

--- a/packages/flutter/example/lib/services/breez_liquid_sdk.dart
+++ b/packages/flutter/example/lib/services/breez_liquid_sdk.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
+import 'package:rxdart/rxdart.dart';
+
+class BreezLiquidSDK {
+  liquid_sdk.BindingLiquidSdk? wallet;
+
+  Future<liquid_sdk.BindingLiquidSdk> connect({
+    required liquid_sdk.ConnectRequest req,
+  }) async {
+    wallet = await liquid_sdk.connect(req: req);
+    _initializeEventsStream(wallet!);
+    _subscribeToSdkStreams(wallet!);
+    await _fetchWalletData(wallet!);
+    return wallet!;
+  }
+
+  void disconnect(liquid_sdk.BindingLiquidSdk sdk) {
+    sdk.disconnect();
+    _unsubscribeFromSdkStreams();
+  }
+
+  Future _fetchWalletData(liquid_sdk.BindingLiquidSdk sdk) async {
+    await _getInfo(sdk);
+    await _listPayments(sdk);
+  }
+
+  Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BindingLiquidSdk sdk) async {
+    final walletInfo = await sdk.getInfo(req: const liquid_sdk.GetInfoRequest(withScan: false));
+    _walletInfoController.add(walletInfo);
+    return walletInfo;
+  }
+
+  Future<List<liquid_sdk.Payment>> _listPayments(liquid_sdk.BindingLiquidSdk sdk) async {
+    final paymentsList = await sdk.listPayments();
+    _paymentsController.add(paymentsList);
+    return paymentsList;
+  }
+
+  StreamSubscription<liquid_sdk.LogEntry>? _breezLogSubscription;
+
+  Stream<liquid_sdk.LogEntry>? _breezLogStream;
+
+  /// Initializes SDK log stream.
+  ///
+  /// Call once on your Dart entrypoint file, e.g.; `lib/main.dart`.
+  void initializeLogStream() {
+    _breezLogStream ??= liquid_sdk.breezLogStream().asBroadcastStream();
+  }
+
+  StreamSubscription<liquid_sdk.LiquidSdkEvent>? _breezEventsSubscription;
+
+  Stream<liquid_sdk.LiquidSdkEvent>? _breezEventsStream;
+
+  void _initializeEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
+    _breezEventsStream ??= sdk.addEventListener().asBroadcastStream();
+  }
+
+  /// Subscribes to SDK's event & log streams.
+  void _subscribeToSdkStreams(liquid_sdk.BindingLiquidSdk sdk) {
+    _subscribeToEventsStream(sdk);
+    _subscribeToLogStream();
+  }
+
+  final StreamController<liquid_sdk.GetInfoResponse> _walletInfoController =
+      BehaviorSubject<liquid_sdk.GetInfoResponse>();
+
+  Stream<liquid_sdk.GetInfoResponse> get walletInfoStream => _walletInfoController.stream;
+
+  final StreamController<liquid_sdk.Payment> _paymentResultStream = StreamController.broadcast();
+
+  final StreamController<List<liquid_sdk.Payment>> _paymentsController =
+      BehaviorSubject<List<liquid_sdk.Payment>>();
+
+  Stream<List<liquid_sdk.Payment>> get paymentsStream => _paymentsController.stream;
+
+  Stream<liquid_sdk.Payment> get paymentResultStream => _paymentResultStream.stream;
+
+  /* TODO: Liquid - Log statements are added for debugging purposes, should be removed after early development stage is complete & events are behaving as expected.*/
+  /// Subscribes to LiquidSdkEvent's stream
+  void _subscribeToEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
+    _breezEventsSubscription = _breezEventsStream?.listen(
+      (event) async {
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentFailed) {
+          _logStreamController
+              .add(liquid_sdk.LogEntry(line: "Payment Failed. ${event.details.swapId}", level: "WARN"));
+          _paymentResultStream.addError(PaymentException(event.details));
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentPending) {
+          _logStreamController
+              .add(liquid_sdk.LogEntry(line: "Payment Pending. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentRefunded) {
+          _logStreamController
+              .add(liquid_sdk.LogEntry(line: "Payment Refunded. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentRefundPending) {
+          _logStreamController.add(
+              liquid_sdk.LogEntry(line: "Pending Payment Refund. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentSucceeded) {
+          _logStreamController
+              .add(liquid_sdk.LogEntry(line: "Payment Succeeded. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+          await _fetchWalletData(sdk);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_PaymentWaitingConfirmation) {
+          _logStreamController.add(liquid_sdk.LogEntry(
+              line: "Payment Waiting Confirmation. ${event.details.swapId}", level: "INFO"));
+          _paymentResultStream.add(event.details);
+        }
+        if (event is liquid_sdk.LiquidSdkEvent_Synced) {
+          _logStreamController.add(const liquid_sdk.LogEntry(line: "Received Synced event.", level: "INFO"));
+          await _fetchWalletData(sdk);
+        }
+      },
+    );
+  }
+
+  final _logStreamController = StreamController<liquid_sdk.LogEntry>.broadcast();
+
+  Stream<liquid_sdk.LogEntry> get logStream => _logStreamController.stream;
+
+  /// Subscribes to SDK's logs stream
+  void _subscribeToLogStream() {
+    _breezLogSubscription = _breezLogStream?.listen((logEntry) {
+      _logStreamController.add(logEntry);
+    }, onError: (e) {
+      _logStreamController.addError(e);
+    });
+  }
+
+  /// Unsubscribes from SDK's event & log streams.
+  void _unsubscribeFromSdkStreams() {
+    _breezEventsSubscription?.cancel();
+    _breezLogSubscription?.cancel();
+  }
+}
+
+// TODO: Liquid - Return this exception from the SDK directly
+class PaymentException {
+  final liquid_sdk.Payment details;
+
+  const PaymentException(this.details);
+}

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -402,10 +402,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -446,6 +446,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  rxdart:
+    dependency: "direct main"
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/packages/flutter/example/pubspec.yaml
+++ b/packages/flutter/example/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   path_provider: ^2.1.3
   qr_flutter: ^4.1.0
   intl: ^0.19.0
+  rxdart: ^0.27.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR addresses
- https://github.com/breez/breez-liquid-sdk/issues/260
- https://github.com/breez/breez-liquid-sdk/issues/264

`BreezLiquidSDK` wrapper class is introduced to handle stream subscription management similar to `BreezSDK`.
- Log stream should be subscribed early by on calling `BreezLiquidSDK.initializeLogStream()` on Dart entrypoint file of applications.
- Event stream subscription will be handle automatically on connecting to wallet.

Although most wallet API's are accessible through importing `'package:breez_liquid/breez_liquid.dart'`, they should be called via `BreezLiquidSDK.wallet` on application layer.

An internal helper method, `_fetchWalletData()`, is added to fetch wallet info and payment list when needed, _e.g.; after connecting to wallet & payments succeed etc._

#### Other changes:
- Direct use of `connect` & `disconnect` is hidden from end-user, only end-points are through `BreezLiquidSDK` wrapper.
- Logs on SDK event handler are added for debugging purposes at this stage of development. They will be removed.
- Updated example app