### PR TITLE
Fix (re)connect swap subscription

### DIFF
--- a/lib/core/src/swapper/boltz_status_stream.rs
+++ b/lib/core/src/swapper/boltz_status_stream.rs
@@ -82,12 +82,12 @@ impl SwapperStatusStream for BoltzStatusStream {
                 debug!("Start of ws stream loop");
                 match self.connect().await {
                     Ok(mut ws_stream) => {
+                        let mut subscription_stream = self.subscription_notifier.subscribe();
+
                         callback.on_stream_reconnect().await;
 
                         let mut interval = tokio::time::interval(keep_alive_ping_interval);
                         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
-                        let mut subscription_stream = self.subscription_notifier.subscribe();
 
                         loop {
                             tokio::select! {


### PR DESCRIPTION
This PR fixes a issue where swaps are not being subscribed to on (re)connect. 

In `on_stream_reconnect()` we are adding swaps to track via `track_swap_id()` which uses the `subscription_notifier` to add swap subscriptions. But because the `on_stream_reconnect()` is called before we subscribe to the `subscription_notifier` broadcasts, the initial subscriptions are lost as there is no receiver.

Fixes #173 