### PR TITLE
Workaround subscriptions not persisting with reconnects

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.5.1"
-source = "git+https://github.com/Blockstream/lwk?rev=ffd793d0a1b1122c9bba7de23ccb73033eded98c#ffd793d0a1b1122c9bba7de23ccb73033eded98c"
+source = "git+https://github.com/dangeross/lwk?branch=savage-try-headers-subscribe#ecf62efbbde5008301a329330d519e93e1e1b462"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.5.1"
-source = "git+https://github.com/Blockstream/lwk?rev=ffd793d0a1b1122c9bba7de23ccb73033eded98c#ffd793d0a1b1122c9bba7de23ccb73033eded98c"
+source = "git+https://github.com/dangeross/lwk?branch=savage-try-headers-subscribe#ecf62efbbde5008301a329330d519e93e1e1b462"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -23,7 +23,8 @@ log = { workspace = true }
 lwk_common = "0.5.1"
 lwk_signer = "0.5.1"
 # Switch back to published version once this PR is merged and included in release: https://github.com/Blockstream/lwk/pull/34 (ETA in v0.5.2)
-lwk_wollet = { git = "https://github.com/Blockstream/lwk", rev = "ffd793d0a1b1122c9bba7de23ccb73033eded98c" }
+#lwk_wollet = { git = "https://github.com/Blockstream/lwk", rev = "ffd793d0a1b1122c9bba7de23ccb73033eded98c" }
+lwk_wollet = { git = "https://github.com/dangeross/lwk", branch = "savage-try-headers-subscribe" }
 #lwk_wollet = "0.5.1"
 rusqlite = { version = "0.31", features = ["backup", "bundled"] }
 rusqlite_migration = "1.0"

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -121,6 +121,7 @@ impl From<EsploraTx> for History {
             txid: value.txid,
             height: status.block_height.unwrap_or_default(),
             block_hash: status.block_hash,
+            block_timestamp: None,
         }
     }
 }


### PR DESCRIPTION
This PR forks the upstream lwk_wollet to add the same logic as in the bitcoin module. If no header is popped then try to subscribe to headers in case the connection was dropped. It might be that the client has reconnected and subscriptions don't persist across connections. Calling `client.block_headers_pop_raw()` doesn't reestablish a connection. Calling `client.ping()` won't help because the successful retry (when reestablishing a connection) will prevent us knowing about the reconnect and not able to re-subscribe to header notifications.

Fixes #314 