### PR TITLE
Hybrid chain service

### DIFF
--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -39,7 +39,7 @@ url = "2.5.0"
 futures-util = { version = "0.3.28", default-features = false, features = ["sink", "std"] }
 async-trait = "0.1.80"
 hex = "0.4"
-reqwest = { version = "=0.11.20", features = ["json"] }
+reqwest = { version = "=0.11.20", features = ["json", "blocking"] }
 electrum-client = { version = "0.19.0" }
 
 [dev-dependencies]

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -39,7 +39,7 @@ url = "2.5.0"
 futures-util = { version = "0.3.28", default-features = false, features = ["sink", "std"] }
 async-trait = "0.1.80"
 hex = "0.4"
-reqwest = { version = "=0.11.20", features = ["json", "blocking"] }
+reqwest = { version = "=0.11.20", features = ["json"] }
 electrum-client = { version = "0.19.0" }
 
 [dev-dependencies]

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -85,7 +85,7 @@ impl LiquidChainService for HybridLiquidChainService {
             .to_hex();
         let url = format!("{}/scripthash/{}/txs", LIQUID_ESPLORA_URL, script_hash);
         // TODO must handle paging -> https://github.com/blockstream/esplora/blob/master/API.md#addresses
-        let response = get_with_retry(&url, 2).await?;
+        let response = get_with_retry(&url, 3).await?;
         let json: Vec<EsploraTx> = response.json().await?;
 
         let history: Vec<History> = json.into_iter().map(Into::into).collect();

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -1,0 +1,128 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use boltz_client::ToHex;
+use log::info;
+use lwk_wollet::{
+    elements::{pset::serialize::Serialize, BlockHash, Script, Transaction, Txid},
+    hashes::{sha256, Hash},
+    BlockchainBackend, ElectrumClient, ElectrumUrl, History,
+};
+use reqwest::Response;
+use serde::Deserialize;
+use std::str::FromStr;
+
+use crate::model::Config;
+
+const LIQUID_ESPLORA_URL: &str = "https://lq1.breez.technology/liquid/api";
+
+#[async_trait]
+pub trait LiquidChainService: Send + Sync {
+    /// Get the blockchain latest block
+    async fn tip(&mut self) -> Result<u32>;
+
+    /// Broadcast a transaction
+    async fn broadcast(&self, tx: &Transaction, swap_id: Option<&str>) -> Result<Txid>;
+
+    /// Get a list of transactions
+    async fn get_transactions(&self, txids: &[Txid]) -> Result<Vec<Transaction>>;
+
+    /// Get the transactions involved in a list of scripts including lowball
+    async fn get_script_history(&self, scripts: &Script) -> Result<Vec<History>>;
+}
+
+#[derive(Deserialize)]
+struct EsploraTx {
+    txid: Txid,
+    status: Status,
+}
+
+// TODO some of this fields may be Option in unconfirmed
+
+#[derive(Deserialize)]
+struct Status {
+    block_height: Option<i32>,
+    block_hash: Option<BlockHash>,
+}
+
+pub(crate) struct HybridLiquidChainService {
+    electrum_client: ElectrumClient,
+}
+
+impl HybridLiquidChainService {
+    pub(crate) fn new(config: Config) -> Result<Self> {
+        let electrum_client =
+            ElectrumClient::new(&ElectrumUrl::new(&config.liquid_electrum_url, true, true))?;
+        Ok(Self { electrum_client })
+    }
+}
+
+#[async_trait]
+impl LiquidChainService for HybridLiquidChainService {
+    async fn tip(&mut self) -> Result<u32> {
+        Ok(self.electrum_client.tip()?.height)
+    }
+
+    async fn broadcast(&self, tx: &Transaction, swap_id: Option<&str>) -> Result<Txid> {
+        let tx_bytes = tx.serialize();
+        info!("tx: {}", tx_bytes.to_hex());
+        let client = reqwest::Client::new();
+        let response = client
+            .post(format!("{LIQUID_ESPLORA_URL}/tx"))
+            .header("Swap-ID", swap_id.unwrap_or_default())
+            .body(tx_bytes.to_hex())
+            .send()
+            .await?;
+        let txid = Txid::from_str(&response.text().await?)?;
+        Ok(txid)
+    }
+
+    async fn get_transactions(&self, txids: &[Txid]) -> Result<Vec<Transaction>> {
+        Ok(self.electrum_client.get_transactions(txids)?)
+    }
+
+    async fn get_script_history(&self, script: &Script) -> Result<Vec<History>> {
+        let script = lwk_wollet::elements::bitcoin::Script::from_bytes(script.as_bytes());
+        let script_hash = sha256::Hash::hash(script.as_bytes())
+            .to_byte_array()
+            .to_hex();
+        let url = format!("{}/scripthash/{}/txs", LIQUID_ESPLORA_URL, script_hash);
+        // TODO must handle paging -> https://github.com/blockstream/esplora/blob/master/API.md#addresses
+        let response = get_with_retry(&url, 2).await?;
+        let json: Vec<EsploraTx> = response.json().await?;
+
+        let history: Vec<History> = json.into_iter().map(Into::into).collect();
+        Ok(history)
+    }
+}
+
+async fn get_with_retry(url: &str, retries: usize) -> Result<Response> {
+    let mut attempt = 0;
+    loop {
+        info!("liquid chain service get_with_retry for url {url}");
+        let response = reqwest::get(url).await?;
+        attempt += 1;
+        // 429 Too many requests
+        // 503 Service Temporarily Unavailable
+        if response.status() == 429 || response.status() == 503 {
+            if attempt >= retries {
+                return Err(anyhow!("Too many retry".to_string()));
+            }
+            let secs = 1 << attempt;
+
+            std::thread::sleep(std::time::Duration::from_secs(secs));
+        } else {
+            return Ok(response);
+        }
+    }
+}
+
+impl From<EsploraTx> for History {
+    fn from(value: EsploraTx) -> Self {
+        let status = value.status;
+        History {
+            txid: value.txid,
+            height: status.block_height.unwrap_or_default(),
+            block_hash: status.block_hash,
+        }
+    }
+}

--- a/lib/core/src/chain/liquid.rs
+++ b/lib/core/src/chain/liquid.rs
@@ -36,8 +36,6 @@ struct EsploraTx {
     status: Status,
 }
 
-// TODO some of this fields may be Option in unconfirmed
-
 #[derive(Deserialize)]
 struct Status {
     block_height: Option<i32>,
@@ -64,7 +62,7 @@ impl LiquidChainService for HybridLiquidChainService {
 
     async fn broadcast(&self, tx: &Transaction, swap_id: Option<&str>) -> Result<Txid> {
         let tx_bytes = tx.serialize();
-        info!("tx: {}", tx_bytes.to_hex());
+        info!("Broadcasting Liquid tx: {}", tx_bytes.to_hex());
         let client = reqwest::Client::new();
         let response = client
             .post(format!("{LIQUID_ESPLORA_URL}/tx"))

--- a/lib/core/src/chain/mod.rs
+++ b/lib/core/src/chain/mod.rs
@@ -1,6 +1,2 @@
 pub(crate) mod bitcoin;
-
-use lwk_wollet::{BlockchainBackend, ElectrumClient};
-
-pub(crate) trait ChainService: Send + Sync + BlockchainBackend {}
-impl ChainService for ElectrumClient {}
+pub(crate) mod liquid;

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -18,6 +18,8 @@ use crate::receive_swap::{
 };
 use crate::utils;
 
+pub const LOWBALL_FEE_RATE: f32 = 0.01;
+
 /// Configuration for the Liquid SDK
 #[derive(Clone, Debug, Serialize)]
 pub struct Config {

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -18,7 +18,7 @@ use crate::receive_swap::{
 };
 use crate::utils;
 
-pub const LOWBALL_FEE_RATE: f32 = 0.01;
+pub const LOWBALL_FEE_RATE_SAT_PER_VBYTE: f32 = 0.01;
 
 /// Configuration for the Liquid SDK
 #[derive(Clone, Debug, Serialize)]

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -345,12 +345,10 @@ impl ReceiveSwapStateHandler {
                 }
                 Ok(())
             }
-            None => {
-                return Err(anyhow!(
-                    "swapper reported lockup wasn't found, txid={} waiting for confirmation",
-                    swap_update_tx.id,
-                ));
-            }
+            None => Err(anyhow!(
+                "swapper reported lockup wasn't found, txid={} waiting for confirmation",
+                swap_update_tx.id,
+            )),
         }
     }
 

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -325,11 +325,7 @@ impl ReceiveSwapStateHandler {
                 info!("swapper lockup found, verifying transaction content...");
 
                 let lockup_tx = utils::deserialize_tx_hex(&swap_update_tx.hex)?;
-                if !lockup_tx
-                    .txid()
-                    .to_hex()
-                    .eq(&lockup_tx_history.unwrap().txid.to_hex())
-                {
+                if !lockup_tx.txid().to_hex().eq(&history.txid.to_hex()) {
                     return Err(anyhow!(
                         "swapper reported txid and transaction hex do not match: {} vs {}",
                         swap_update_tx.id,

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -565,7 +565,11 @@ impl LiquidSdk {
     async fn estimate_onchain_tx_fee(&self, amount_sat: u64, address: &str) -> Result<u64> {
         Ok(self
             .onchain_wallet
-            .build_tx(Some(LOWBALL_FEE_RATE * 1000.0), address, amount_sat)
+            .build_tx(
+                Some(LOWBALL_FEE_RATE_SAT_PER_VBYTE * 1000.0),
+                address,
+                amount_sat,
+            )
             .await?
             .all_fees()
             .values()

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -565,7 +565,7 @@ impl LiquidSdk {
     async fn estimate_onchain_tx_fee(&self, amount_sat: u64, address: &str) -> Result<u64> {
         Ok(self
             .onchain_wallet
-            .build_tx(Some(10.0), address, amount_sat)
+            .build_tx(Some(LOWBALL_FEE_RATE * 1000.0), address, amount_sat)
             .await?
             .all_fees()
             .values()

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -13,7 +13,7 @@ use tokio::sync::{broadcast, Mutex};
 
 use crate::chain::liquid::LiquidChainService;
 use crate::model::PaymentState::{Complete, Created, Failed, Pending, TimedOut};
-use crate::model::{Config, SendSwap, LOWBALL_FEE_RATE};
+use crate::model::{Config, SendSwap, LOWBALL_FEE_RATE_SAT_PER_VBYTE};
 use crate::swapper::Swapper;
 use crate::wallet::OnchainWallet;
 use crate::{ensure_sdk, get_invoice_amount};
@@ -196,7 +196,7 @@ impl SendSwapStateHandler {
         let lockup_tx = self
             .onchain_wallet
             .build_tx(
-                Some(LOWBALL_FEE_RATE * 1000.0),
+                Some(LOWBALL_FEE_RATE_SAT_PER_VBYTE * 1000.0),
                 &create_response.address,
                 create_response.expected_amount,
             )

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -13,7 +13,7 @@ use tokio::sync::{broadcast, Mutex};
 
 use crate::chain::liquid::LiquidChainService;
 use crate::model::PaymentState::{Complete, Created, Failed, Pending, TimedOut};
-use crate::model::{Config, SendSwap};
+use crate::model::{Config, SendSwap, LOWBALL_FEE_RATE};
 use crate::swapper::Swapper;
 use crate::wallet::OnchainWallet;
 use crate::{ensure_sdk, get_invoice_amount};
@@ -196,7 +196,7 @@ impl SendSwapStateHandler {
         let lockup_tx = self
             .onchain_wallet
             .build_tx(
-                Some(10.0),
+                Some(LOWBALL_FEE_RATE * 1000.0),
                 &create_response.address,
                 create_response.expected_amount,
             )

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -11,7 +11,7 @@ use lwk_wollet::elements::Transaction;
 use lwk_wollet::hashes::{sha256, Hash};
 use tokio::sync::{broadcast, Mutex};
 
-use crate::chain::ChainService;
+use crate::chain::liquid::LiquidChainService;
 use crate::model::PaymentState::{Complete, Created, Failed, Pending, TimedOut};
 use crate::model::{Config, SendSwap};
 use crate::swapper::Swapper;
@@ -28,7 +28,7 @@ pub(crate) struct SendSwapStateHandler {
     onchain_wallet: Arc<dyn OnchainWallet>,
     persister: Arc<Persister>,
     swapper: Arc<dyn Swapper>,
-    chain_service: Arc<Mutex<dyn ChainService>>,
+    chain_service: Arc<Mutex<dyn LiquidChainService>>,
     subscription_notifier: broadcast::Sender<String>,
 }
 
@@ -38,7 +38,7 @@ impl SendSwapStateHandler {
         onchain_wallet: Arc<dyn OnchainWallet>,
         persister: Arc<Persister>,
         swapper: Arc<dyn Swapper>,
-        chain_service: Arc<Mutex<dyn ChainService>>,
+        chain_service: Arc<Mutex<dyn LiquidChainService>>,
     ) -> Self {
         let (subscription_notifier, _) = broadcast::channel::<String>(30);
         Self {
@@ -196,20 +196,22 @@ impl SendSwapStateHandler {
         let lockup_tx = self
             .onchain_wallet
             .build_tx(
-                None,
+                Some(10.0),
                 &create_response.address,
                 create_response.expected_amount,
             )
             .await?;
 
+        info!("broadcasting lockup tx {}", lockup_tx.txid());
         let lockup_tx_id = self
             .chain_service
             .lock()
             .await
-            .broadcast(&lockup_tx)?
+            .broadcast(&lockup_tx, Some(swap_id))
+            .await?
             .to_string();
 
-        debug!("Successfully broadcast lockup tx for Send Swap {swap_id}. Lockup tx id: {lockup_tx_id}");
+        info!("Successfully broadcast lockup tx for Send Swap {swap_id}. Lockup tx id: {lockup_tx_id}");
         Ok(lockup_tx)
     }
 
@@ -285,10 +287,8 @@ impl SendSwapStateHandler {
             .chain_service
             .lock()
             .await
-            .get_scripts_history(&[&swap_script_pk])?
-            .into_iter()
-            .flatten()
-            .collect();
+            .get_script_history(&swap_script_pk)
+            .await?;
 
         // We expect at most 2 txs: lockup and maybe the claim
         ensure_sdk!(
@@ -311,6 +311,7 @@ impl SendSwapStateHandler {
                     .lock()
                     .await
                     .get_transactions(&[claim_tx_id])
+                    .await
                     .map_err(|e| anyhow!("Failed to fetch claim tx {claim_tx_id}: {e}"))?
                     .first()
                     .cloned()


### PR DESCRIPTION
This PR reimplement the liquid chain service as a hybrid service. Still using electrum apart from the broadcast and get_script_history which uses the lowball node.
Also added verification for the swapper reported tx id and content before moving to the claim.