### PR TITLE
Monitor chain swap addresses

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -70,6 +70,8 @@ pub(crate) enum Command {
         // Fee rate to use
         sat_per_vbyte: u32,
     },
+    /// Rescan onchain swaps
+    RescanOnchainSwaps,
     /// Get the balance and general info of the current instance
     GetInfo,
     /// Sync local data with mempool and onchain data
@@ -293,6 +295,10 @@ pub(crate) async fn handle_command(
                 })
                 .await?;
             command_result!(res)
+        }
+        Command::RescanOnchainSwaps => {
+            sdk.rescan_onchain_swaps().await?;
+            command_result!("Rescanned successfully")
         }
         Command::Sync => {
             sdk.sync().await?;

--- a/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
+++ b/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
@@ -28,6 +28,11 @@ typedef struct _Dart_Handle* Dart_Handle;
  */
 #define DEFAULT_ZERO_CONF_MAX_SAT 100000
 
+/**
+ * Number of blocks to monitor a swap after its timeout block height
+ */
+#define CHAIN_SWAP_MONTIORING_PERIOD_BITCOIN_BLOCKS 4320
+
 typedef struct wire_cst_list_prim_u_8_strict {
   uint8_t *ptr;
   int32_t len;
@@ -802,6 +807,9 @@ void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_refund(int64_t 
                                                                         uintptr_t that,
                                                                         struct wire_cst_refund_request *req);
 
+void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps(int64_t port_,
+                                                                                      uintptr_t that);
+
 WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_restore(uintptr_t that,
                                                                                          struct wire_cst_restore_request *req);
 
@@ -992,6 +1000,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_receive_onchain);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_receive_payment);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_refund);
+    dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_restore);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_send_payment);
     dummy_var ^= ((int64_t) (void*) frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_sync);

--- a/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
+++ b/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
@@ -704,8 +704,9 @@ typedef struct wire_cst_payment_error {
 } wire_cst_payment_error;
 
 typedef struct wire_cst_prepare_refund_response {
-  uint32_t refund_tx_vsize;
-  uint64_t refund_tx_fee_sat;
+  uint32_t tx_vsize;
+  uint64_t tx_fee_sat;
+  struct wire_cst_list_prim_u_8_strict *refund_tx_id;
 } wire_cst_prepare_refund_response;
 
 typedef struct wire_cst_receive_onchain_response {

--- a/lib/bindings/src/breez_liquid_sdk.udl
+++ b/lib/bindings/src/breez_liquid_sdk.udl
@@ -518,6 +518,9 @@ interface BindingLiquidSdk {
     RefundResponse refund(RefundRequest req);
 
     [Throws=LiquidSdkError]
+    void rescan_onchain_swaps();
+
+    [Throws=LiquidSdkError]
     void sync();
 
     [Throws=LiquidSdkError]

--- a/lib/bindings/src/breez_liquid_sdk.udl
+++ b/lib/bindings/src/breez_liquid_sdk.udl
@@ -416,8 +416,9 @@ dictionary PrepareRefundRequest {
 };
 
 dictionary PrepareRefundResponse {
-    u32 refund_tx_vsize;
-    u64 refund_tx_fee_sat;
+    u32 tx_vsize;
+    u64 tx_fee_sat;
+    string? refund_tx_id = null;
 };
 
 dictionary RefundRequest {

--- a/lib/bindings/src/breez_liquid_sdk.udl
+++ b/lib/bindings/src/breez_liquid_sdk.udl
@@ -401,6 +401,7 @@ enum PaymentState {
     "Failed",
     "TimedOut",
     "Refundable",
+    "RefundPending",
 };
 
 dictionary RefundableSwap {

--- a/lib/bindings/src/lib.rs
+++ b/lib/bindings/src/lib.rs
@@ -193,6 +193,10 @@ impl BindingLiquidSdk {
         rt().block_on(self.sdk.refund(&req))
     }
 
+    pub fn rescan_onchain_swaps(&self) -> LiquidSdkResult<()> {
+        rt().block_on(self.sdk.rescan_onchain_swaps())
+    }
+
     pub fn sync(&self) -> LiquidSdkResult<()> {
         rt().block_on(self.sdk.sync()).map_err(Into::into)
     }

--- a/lib/core/src/bindings.rs
+++ b/lib/core/src/bindings.rs
@@ -210,6 +210,10 @@ impl BindingLiquidSdk {
         self.sdk.refund(&req).await
     }
 
+    pub async fn rescan_onchain_swaps(&self) -> Result<(), LiquidSdkError> {
+        self.sdk.rescan_onchain_swaps().await
+    }
+
     pub async fn sync(&self) -> Result<(), LiquidSdkError> {
         self.sdk.sync().await.map_err(Into::into)
     }

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -138,9 +138,10 @@ impl ChainSwapStateHandler {
                 "Chain Swap {} has {} confirmed and {} unconfirmed sats",
                 swap.id, script_balance.confirmed, script_balance.unconfirmed
             );
+
             if script_balance.confirmed > 0
+                && script_balance.unconfirmed == 0
                 && swap.state != Refundable
-                && swap.state != RefundPending
             {
                 // If there are unspent funds sent to the lockup script address then set
                 // the state to Refundable.
@@ -679,7 +680,7 @@ impl ChainSwapStateHandler {
                 err: format!("Cannot transition from {from_state:?} to TimedOut state"),
             }),
 
-            (Created | Pending | Failed | Complete, Refundable) => Ok(()),
+            (Created | Pending | RefundPending | Failed | Complete, Refundable) => Ok(()),
             (_, Refundable) => Err(PaymentError::Generic {
                 err: format!("Cannot transition from {from_state:?} to Refundable state"),
             }),
@@ -733,7 +734,7 @@ mod tests {
             (TimedOut, HashSet::from([Failed])),
             (Complete, HashSet::from([Refundable])),
             (Refundable, HashSet::from([RefundPending, Failed])),
-            (RefundPending, HashSet::from([Complete, Failed])),
+            (RefundPending, HashSet::from([Refundable, Complete, Failed])),
             (Failed, HashSet::from([Failed, Refundable])),
         ]);
 

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -138,7 +138,8 @@ impl ChainSwapStateHandler {
                 .filter(|u| u.height > 0)
                 .map(|u| u.value)
                 .sum();
-            if confirmed_unspent_sat > 0 && swap.state != Refundable {
+            if confirmed_unspent_sat > 0 && swap.state != Refundable && swap.state != RefundPending
+            {
                 // If there are unspent funds sent to the lockup script address then set
                 // the state to Refundable.
                 info!(

--- a/lib/core/src/chain_swap.rs
+++ b/lib/core/src/chain_swap.rs
@@ -104,7 +104,9 @@ impl ChainSwapStateHandler {
             current_height
         );
         for swap in chain_swaps {
-            self.rescan_chain_swap(&swap, current_height).await?
+            if let Err(e) = self.rescan_chain_swap(&swap, current_height).await {
+                error!("Error rescanning Chain Swap {}: {e:?}", swap.id);
+            }
         }
         Ok(())
     }

--- a/lib/core/src/frb_generated.io.rs
+++ b/lib/core/src/frb_generated.io.rs
@@ -2374,6 +2374,14 @@ pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_re
 }
 
 #[no_mangle]
+pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps(
+    port_: i64,
+    that: usize,
+) {
+    wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps_impl(port_, that)
+}
+
+#[no_mangle]
 pub extern "C" fn frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_restore(
     that: usize,
     req: *mut wire_cst_restore_request,

--- a/lib/core/src/frb_generated.io.rs
+++ b/lib/core/src/frb_generated.io.rs
@@ -1195,8 +1195,9 @@ impl CstDecode<crate::model::PrepareRefundResponse> for wire_cst_prepare_refund_
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> crate::model::PrepareRefundResponse {
         crate::model::PrepareRefundResponse {
-            refund_tx_vsize: self.refund_tx_vsize.cst_decode(),
-            refund_tx_fee_sat: self.refund_tx_fee_sat.cst_decode(),
+            tx_vsize: self.tx_vsize.cst_decode(),
+            tx_fee_sat: self.tx_fee_sat.cst_decode(),
+            refund_tx_id: self.refund_tx_id.cst_decode(),
         }
     }
 }
@@ -1969,8 +1970,9 @@ impl Default for wire_cst_prepare_refund_request {
 impl NewWithNullPtr for wire_cst_prepare_refund_response {
     fn new_with_null_ptr() -> Self {
         Self {
-            refund_tx_vsize: Default::default(),
-            refund_tx_fee_sat: Default::default(),
+            tx_vsize: Default::default(),
+            tx_fee_sat: Default::default(),
+            refund_tx_id: core::ptr::null_mut(),
         }
     }
 }
@@ -3570,8 +3572,9 @@ pub struct wire_cst_prepare_refund_request {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct wire_cst_prepare_refund_response {
-    refund_tx_vsize: u32,
-    refund_tx_fee_sat: u64,
+    tx_vsize: u32,
+    tx_fee_sat: u64,
+    refund_tx_id: *mut wire_cst_list_prim_u_8_strict,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -39,7 +39,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.0.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1268203752;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1515195984;
 
 // Section: executor
 
@@ -1015,6 +1015,52 @@ fn wire__crate__bindings__BindingLiquidSdk_refund_impl(
                         let output_ok =
                             crate::bindings::BindingLiquidSdk::refund(&*api_that_guard, api_req)
                                 .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    that: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<BindingLiquidSdk>>,
+    >,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::DcoCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "BindingLiquidSdk_rescan_onchain_swaps",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_that = that.cst_decode();
+            move |context| async move {
+                transform_result_dco::<_, _, crate::error::LiquidSdkError>(
+                    (move || async move {
+                        let mut api_that_guard = None;
+                        let decode_indices_ =
+                            flutter_rust_bridge::for_generated::lockable_compute_decode_order(
+                                vec![flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                    &api_that, 0, false,
+                                )],
+                            );
+                        for i in decode_indices_ {
+                            match i {
+                                0 => {
+                                    api_that_guard =
+                                        Some(api_that.lockable_decode_async_ref().await)
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        let api_that_guard = api_that_guard.unwrap();
+                        let output_ok = crate::bindings::BindingLiquidSdk::rescan_onchain_swaps(
+                            &*api_that_guard,
+                        )
+                        .await?;
                         Ok(output_ok)
                     })()
                     .await,

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2802,11 +2802,13 @@ impl SseDecode for crate::model::PrepareRefundRequest {
 impl SseDecode for crate::model::PrepareRefundResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_refundTxVsize = <u32>::sse_decode(deserializer);
-        let mut var_refundTxFeeSat = <u64>::sse_decode(deserializer);
+        let mut var_txVsize = <u32>::sse_decode(deserializer);
+        let mut var_txFeeSat = <u64>::sse_decode(deserializer);
+        let mut var_refundTxId = <Option<String>>::sse_decode(deserializer);
         return crate::model::PrepareRefundResponse {
-            refund_tx_vsize: var_refundTxVsize,
-            refund_tx_fee_sat: var_refundTxFeeSat,
+            tx_vsize: var_txVsize,
+            tx_fee_sat: var_txFeeSat,
+            refund_tx_id: var_refundTxId,
         };
     }
 }
@@ -4245,8 +4247,9 @@ impl flutter_rust_bridge::IntoIntoDart<crate::model::PrepareRefundRequest>
 impl flutter_rust_bridge::IntoDart for crate::model::PrepareRefundResponse {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
-            self.refund_tx_vsize.into_into_dart().into_dart(),
-            self.refund_tx_fee_sat.into_into_dart().into_dart(),
+            self.tx_vsize.into_into_dart().into_dart(),
+            self.tx_fee_sat.into_into_dart().into_dart(),
+            self.refund_tx_id.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -5563,8 +5566,9 @@ impl SseEncode for crate::model::PrepareRefundRequest {
 impl SseEncode for crate::model::PrepareRefundResponse {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <u32>::sse_encode(self.refund_tx_vsize, serializer);
-        <u64>::sse_encode(self.refund_tx_fee_sat, serializer);
+        <u32>::sse_encode(self.tx_vsize, serializer);
+        <u64>::sse_encode(self.tx_fee_sat, serializer);
+        <Option<String>>::sse_encode(self.refund_tx_id, serializer);
     }
 }
 

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1580,6 +1580,7 @@ impl CstDecode<crate::model::PaymentState> for i32 {
             3 => crate::model::PaymentState::Failed,
             4 => crate::model::PaymentState::TimedOut,
             5 => crate::model::PaymentState::Refundable,
+            6 => crate::model::PaymentState::RefundPending,
             _ => unreachable!("Invalid variant for PaymentState: {}", self),
         }
     }
@@ -2748,6 +2749,7 @@ impl SseDecode for crate::model::PaymentState {
             3 => crate::model::PaymentState::Failed,
             4 => crate::model::PaymentState::TimedOut,
             5 => crate::model::PaymentState::Refundable,
+            6 => crate::model::PaymentState::RefundPending,
             _ => unreachable!("Invalid variant for PaymentState: {}", inner),
         };
     }
@@ -4127,6 +4129,7 @@ impl flutter_rust_bridge::IntoDart for crate::model::PaymentState {
             Self::Failed => 3.into_dart(),
             Self::TimedOut => 4.into_dart(),
             Self::Refundable => 5.into_dart(),
+            Self::RefundPending => 6.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -5530,6 +5533,7 @@ impl SseEncode for crate::model::PaymentState {
                 crate::model::PaymentState::Failed => 3,
                 crate::model::PaymentState::TimedOut => 4,
                 crate::model::PaymentState::Refundable => 5,
+                crate::model::PaymentState::RefundPending => 6,
                 _ => {
                     unimplemented!("");
                 }

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -250,8 +250,9 @@ pub struct PrepareRefundRequest {
 
 #[derive(Debug, Serialize)]
 pub struct PrepareRefundResponse {
-    pub refund_tx_vsize: u32,
-    pub refund_tx_fee_sat: u64,
+    pub tx_vsize: u32,
+    pub tx_fee_sat: u64,
+    pub refund_tx_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -682,11 +682,11 @@ pub enum PaymentState {
     ///
     /// ## Send Swaps
     ///
-    /// Covers the cases when
-    /// - our lockup tx was broadcast or
-    /// - a refund was initiated and our refund tx was broadcast
+    /// This is the status when our lockup tx was broadcast
     ///
-    /// When the refund tx is broadcast, `refund_tx_id` is set in the swap.
+    /// ## Chain Swaps
+    ///
+    /// This is the status when the user lockup tx was broadcast
     ///
     /// ## No swap data available
     ///
@@ -697,7 +697,7 @@ pub enum PaymentState {
     ///
     /// Covers the case when the claim tx is confirmed.
     ///
-    /// ## Send Swaps
+    /// ## Send and Chain Swaps
     ///
     /// This is the status when the claim tx is broadcast and we see it in the mempool.
     ///
@@ -710,12 +710,12 @@ pub enum PaymentState {
     ///
     /// This is the status when the swap failed for any reason and the Receive could not complete.
     ///
-    /// ## Send Swaps
+    /// ## Send and Chain Swaps
     ///
     /// This is the status when a swap refund was initiated and the refund tx is confirmed.
     Failed = 3,
 
-    /// ## Send Swaps
+    /// ## Send and Outgoing Chain Swaps
     ///
     /// This covers the case when the swap state is still Created and the swap fails to reach the
     /// Pending state in time. The TimedOut state indicates the lockup tx should never be broadcast.
@@ -726,6 +726,13 @@ pub enum PaymentState {
     /// This covers the case when the swap failed for any reason and there is a user lockup tx.
     /// The swap in this case has to be manually refunded with a provided Bitcoin address
     Refundable = 5,
+
+    /// ## Send and Chain Swaps
+    ///
+    /// This is the status when a refund was initiated and our refund tx was broadcast
+    ///
+    /// When the refund tx is broadcast, `refund_tx_id` is set in the swap.
+    RefundPending = 6,
 }
 impl ToSql for PaymentState {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
@@ -742,6 +749,7 @@ impl FromSql for PaymentState {
                 3 => Ok(PaymentState::Failed),
                 4 => Ok(PaymentState::TimedOut),
                 5 => Ok(PaymentState::Refundable),
+                6 => Ok(PaymentState::RefundPending),
                 _ => Err(FromSqlError::OutOfRange(i)),
             },
             _ => Err(FromSqlError::InvalidType),

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -12,7 +12,9 @@ use lwk_wollet::History;
 use tokio::sync::{broadcast, Mutex};
 
 use crate::chain::liquid::LiquidChainService;
-use crate::model::PaymentState::{Complete, Created, Failed, Pending, Refundable, TimedOut};
+use crate::model::PaymentState::{
+    Complete, Created, Failed, Pending, RefundPending, Refundable, TimedOut,
+};
 use crate::model::{Config, PaymentTxData, PaymentType, ReceiveSwap};
 use crate::{ensure_sdk, utils};
 use crate::{
@@ -305,6 +307,10 @@ impl ReceiveSwapStateHandler {
                 err: format!("Cannot transition from {from_state:?} to Refundable state"),
             }),
 
+            (_, RefundPending) => Err(PaymentError::Generic {
+                err: format!("Cannot transition from {from_state:?} to RefundPending state"),
+            }),
+
             (Complete, Failed) => Err(PaymentError::Generic {
                 err: format!("Cannot transition from {from_state:?} to Failed state"),
             }),
@@ -421,6 +427,7 @@ mod tests {
             (TimedOut, HashSet::from([TimedOut, Failed])),
             (Complete, HashSet::from([])),
             (Refundable, HashSet::from([Failed])),
+            (RefundPending, HashSet::from([Failed])),
             (Failed, HashSet::from([Failed])),
         ]);
 

--- a/lib/core/src/test_utils.rs
+++ b/lib/core/src/test_utils.rs
@@ -71,6 +71,7 @@ pub(crate) fn new_chain_swap_state_handler(
     )?));
 
     ChainSwapStateHandler::new(
+        config,
         onchain_wallet,
         persister,
         swapper,

--- a/packages/dart/lib/src/bindings.dart
+++ b/packages/dart/lib/src/bindings.dart
@@ -73,6 +73,8 @@ abstract class BindingLiquidSdk implements RustOpaqueInterface {
 
   Future<RefundResponse> refund({required RefundRequest req});
 
+  Future<void> rescanOnchainSwaps();
+
   void restore({required RestoreRequest req});
 
   Future<SendPaymentResponse> sendPayment({required PrepareSendResponse req});

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2043,10 +2043,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareRefundResponse dco_decode_prepare_refund_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return PrepareRefundResponse(
-      refundTxVsize: dco_decode_u_32(arr[0]),
-      refundTxFeeSat: dco_decode_u_64(arr[1]),
+      txVsize: dco_decode_u_32(arr[0]),
+      txFeeSat: dco_decode_u_64(arr[1]),
+      refundTxId: dco_decode_opt_String(arr[2]),
     );
   }
 
@@ -3438,9 +3439,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   PrepareRefundResponse sse_decode_prepare_refund_response(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_refundTxVsize = sse_decode_u_32(deserializer);
-    var var_refundTxFeeSat = sse_decode_u_64(deserializer);
-    return PrepareRefundResponse(refundTxVsize: var_refundTxVsize, refundTxFeeSat: var_refundTxFeeSat);
+    var var_txVsize = sse_decode_u_32(deserializer);
+    var var_txFeeSat = sse_decode_u_64(deserializer);
+    var var_refundTxId = sse_decode_opt_String(deserializer);
+    return PrepareRefundResponse(txVsize: var_txVsize, txFeeSat: var_txFeeSat, refundTxId: var_refundTxId);
   }
 
   @protected
@@ -4754,8 +4756,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_prepare_refund_response(PrepareRefundResponse self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_u_32(self.refundTxVsize, serializer);
-    sse_encode_u_64(self.refundTxFeeSat, serializer);
+    sse_encode_u_32(self.txVsize, serializer);
+    sse_encode_u_64(self.txFeeSat, serializer);
+    sse_encode_opt_String(self.refundTxId, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -55,7 +55,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.0.0';
 
   @override
-  int get rustContentHash => -1268203752;
+  int get rustContentHash => 1515195984;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'breez_liquid_sdk',
@@ -119,6 +119,8 @@ abstract class RustLibApi extends BaseApi {
 
   Future<RefundResponse> crateBindingsBindingLiquidSdkRefund(
       {required BindingLiquidSdk that, required RefundRequest req});
+
+  Future<void> crateBindingsBindingLiquidSdkRescanOnchainSwaps({required BindingLiquidSdk that});
 
   void crateBindingsBindingLiquidSdkRestore({required BindingLiquidSdk that, required RestoreRequest req});
 
@@ -687,6 +689,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateBindingsBindingLiquidSdkRefundConstMeta => const TaskConstMeta(
         debugName: "BindingLiquidSdk_refund",
         argNames: ["that", "req"],
+      );
+
+  @override
+  Future<void> crateBindingsBindingLiquidSdkRescanOnchainSwaps({required BindingLiquidSdk that}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        var arg0 =
+            cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerBindingLiquidSdk(
+                that);
+        return wire.wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps(port_, arg0);
+      },
+      codec: DcoCodec(
+        decodeSuccessData: dco_decode_unit,
+        decodeErrorData: dco_decode_liquid_sdk_error,
+      ),
+      constMeta: kCrateBindingsBindingLiquidSdkRescanOnchainSwapsConstMeta,
+      argValues: [that],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateBindingsBindingLiquidSdkRescanOnchainSwapsConstMeta => const TaskConstMeta(
+        debugName: "BindingLiquidSdk_rescan_onchain_swaps",
+        argNames: ["that"],
       );
 
   @override
@@ -5012,6 +5038,10 @@ class BindingLiquidSdkImpl extends RustOpaque implements BindingLiquidSdk {
 
   Future<RefundResponse> refund({required RefundRequest req}) =>
       RustLib.instance.api.crateBindingsBindingLiquidSdkRefund(that: this, req: req);
+
+  Future<void> rescanOnchainSwaps() => RustLib.instance.api.crateBindingsBindingLiquidSdkRescanOnchainSwaps(
+        that: this,
+      );
 
   void restore({required RestoreRequest req}) =>
       RustLib.instance.api.crateBindingsBindingLiquidSdkRestore(that: this, req: req);

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2178,8 +2178,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void cst_api_fill_to_wire_prepare_refund_response(
       PrepareRefundResponse apiObj, wire_cst_prepare_refund_response wireObj) {
-    wireObj.refund_tx_vsize = cst_encode_u_32(apiObj.refundTxVsize);
-    wireObj.refund_tx_fee_sat = cst_encode_u_64(apiObj.refundTxFeeSat);
+    wireObj.tx_vsize = cst_encode_u_32(apiObj.txVsize);
+    wireObj.tx_fee_sat = cst_encode_u_64(apiObj.txFeeSat);
+    wireObj.refund_tx_id = cst_encode_opt_String(apiObj.refundTxId);
   }
 
   @protected
@@ -4795,10 +4796,12 @@ final class wire_cst_payment_error extends ffi.Struct {
 
 final class wire_cst_prepare_refund_response extends ffi.Struct {
   @ffi.Uint32()
-  external int refund_tx_vsize;
+  external int tx_vsize;
 
   @ffi.Uint64()
-  external int refund_tx_fee_sat;
+  external int tx_fee_sat;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 }
 
 final class wire_cst_receive_onchain_response extends ffi.Struct {

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -3191,6 +3191,22 @@ class RustLibWire implements BaseWire {
       _wire__crate__bindings__BindingLiquidSdk_refundPtr
           .asFunction<void Function(int, int, ffi.Pointer<wire_cst_refund_request>)>();
 
+  void wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps(
+    int port_,
+    int that,
+  ) {
+    return _wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps(
+      port_,
+      that,
+    );
+  }
+
+  late final _wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swapsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+          'frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps');
+  late final _wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps =
+      _wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swapsPtr.asFunction<void Function(int, int)>();
+
   WireSyncRust2DartDco wire__crate__bindings__BindingLiquidSdk_restore(
     int that,
     ffi.Pointer<wire_cst_restore_request> req,
@@ -4831,3 +4847,5 @@ const double DEFAULT_ZERO_CONF_MIN_FEE_RATE_TESTNET = 0.1;
 const double DEFAULT_ZERO_CONF_MIN_FEE_RATE_MAINNET = 0.01;
 
 const int DEFAULT_ZERO_CONF_MAX_SAT = 100000;
+
+const int CHAIN_SWAP_MONTIORING_PERIOD_BITCOIN_BLOCKS = 4320;

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -367,11 +367,11 @@ enum PaymentState {
   ///
   /// ## Send Swaps
   ///
-  /// Covers the cases when
-  /// - our lockup tx was broadcast or
-  /// - a refund was initiated and our refund tx was broadcast
+  /// This is the status when our lockup tx was broadcast
   ///
-  /// When the refund tx is broadcast, `refund_tx_id` is set in the swap.
+  /// ## Chain Swaps
+  ///
+  /// This is the status when the user lockup tx was broadcast
   ///
   /// ## No swap data available
   ///
@@ -382,7 +382,7 @@ enum PaymentState {
   ///
   /// Covers the case when the claim tx is confirmed.
   ///
-  /// ## Send Swaps
+  /// ## Send and Chain Swaps
   ///
   /// This is the status when the claim tx is broadcast and we see it in the mempool.
   ///
@@ -395,12 +395,12 @@ enum PaymentState {
   ///
   /// This is the status when the swap failed for any reason and the Receive could not complete.
   ///
-  /// ## Send Swaps
+  /// ## Send and Chain Swaps
   ///
   /// This is the status when a swap refund was initiated and the refund tx is confirmed.
   failed,
 
-  /// ## Send Swaps
+  /// ## Send and Outgoing Chain Swaps
   ///
   /// This covers the case when the swap state is still Created and the swap fails to reach the
   /// Pending state in time. The TimedOut state indicates the lockup tx should never be broadcast.
@@ -411,6 +411,13 @@ enum PaymentState {
   /// This covers the case when the swap failed for any reason and there is a user lockup tx.
   /// The swap in this case has to be manually refunded with a provided Bitcoin address
   refundable,
+
+  /// ## Send and Chain Swaps
+  ///
+  /// This is the status when a refund was initiated and our refund tx was broadcast
+  ///
+  /// When the refund tx is broadcast, `refund_tx_id` is set in the swap.
+  refundPending,
   ;
 }
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -560,24 +560,27 @@ class PrepareRefundRequest {
 }
 
 class PrepareRefundResponse {
-  final int refundTxVsize;
-  final BigInt refundTxFeeSat;
+  final int txVsize;
+  final BigInt txFeeSat;
+  final String? refundTxId;
 
   const PrepareRefundResponse({
-    required this.refundTxVsize,
-    required this.refundTxFeeSat,
+    required this.txVsize,
+    required this.txFeeSat,
+    this.refundTxId,
   });
 
   @override
-  int get hashCode => refundTxVsize.hashCode ^ refundTxFeeSat.hashCode;
+  int get hashCode => txVsize.hashCode ^ txFeeSat.hashCode ^ refundTxId.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is PrepareRefundResponse &&
           runtimeType == other.runtimeType &&
-          refundTxVsize == other.refundTxVsize &&
-          refundTxFeeSat == other.refundTxFeeSat;
+          txVsize == other.txVsize &&
+          txFeeSat == other.txFeeSat &&
+          refundTxId == other.refundTxId;
 }
 
 class PrepareSendRequest {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -435,6 +435,23 @@ class FlutterBreezLiquidBindings {
       _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_refundPtr
           .asFunction<void Function(int, int, ffi.Pointer<wire_cst_refund_request>)>();
 
+  void frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps(
+    int port_,
+    int that,
+  ) {
+    return _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps(
+      port_,
+      that,
+    );
+  }
+
+  late final _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swapsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+          'frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps');
+  late final _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swaps =
+      _frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_rescan_onchain_swapsPtr
+          .asFunction<void Function(int, int)>();
+
   WireSyncRust2DartDco frbgen_breez_liquid_wire__crate__bindings__BindingLiquidSdk_restore(
     int that,
     ffi.Pointer<wire_cst_restore_request> req,
@@ -2145,3 +2162,5 @@ const double DEFAULT_ZERO_CONF_MIN_FEE_RATE_TESTNET = 0.1;
 const double DEFAULT_ZERO_CONF_MIN_FEE_RATE_MAINNET = 0.01;
 
 const int DEFAULT_ZERO_CONF_MAX_SAT = 100000;
+
+const int CHAIN_SWAP_MONTIORING_PERIOD_BITCOIN_BLOCKS = 4320;

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -2107,10 +2107,12 @@ final class wire_cst_payment_error extends ffi.Struct {
 
 final class wire_cst_prepare_refund_response extends ffi.Struct {
   @ffi.Uint32()
-  external int refund_tx_vsize;
+  external int tx_vsize;
 
   @ffi.Uint64()
-  external int refund_tx_fee_sat;
+  external int tx_fee_sat;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> refund_tx_id;
 }
 
 final class wire_cst_receive_onchain_response extends ffi.Struct {

--- a/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKMapper.kt
@@ -1289,25 +1289,28 @@ fun asPrepareRefundResponse(prepareRefundResponse: ReadableMap): PrepareRefundRe
     if (!validateMandatoryFields(
             prepareRefundResponse,
             arrayOf(
-                "refundTxVsize",
-                "refundTxFeeSat",
+                "txVsize",
+                "txFeeSat",
             ),
         )
     ) {
         return null
     }
-    val refundTxVsize = prepareRefundResponse.getInt("refundTxVsize").toUInt()
-    val refundTxFeeSat = prepareRefundResponse.getDouble("refundTxFeeSat").toULong()
+    val txVsize = prepareRefundResponse.getInt("txVsize").toUInt()
+    val txFeeSat = prepareRefundResponse.getDouble("txFeeSat").toULong()
+    val refundTxId = if (hasNonNullKey(prepareRefundResponse, "refundTxId")) prepareRefundResponse.getString("refundTxId") else null
     return PrepareRefundResponse(
-        refundTxVsize,
-        refundTxFeeSat,
+        txVsize,
+        txFeeSat,
+        refundTxId,
     )
 }
 
 fun readableMapOf(prepareRefundResponse: PrepareRefundResponse): ReadableMap =
     readableMapOf(
-        "refundTxVsize" to prepareRefundResponse.refundTxVsize,
-        "refundTxFeeSat" to prepareRefundResponse.refundTxFeeSat,
+        "txVsize" to prepareRefundResponse.txVsize,
+        "txFeeSat" to prepareRefundResponse.txFeeSat,
+        "refundTxId" to prepareRefundResponse.refundTxId,
     )
 
 fun asPrepareRefundResponseList(arr: ReadableArray): List<PrepareRefundResponse> {

--- a/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKModule.kt
+++ b/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKModule.kt
@@ -390,6 +390,18 @@ class BreezLiquidSDKModule(
     }
 
     @ReactMethod
+    fun rescanOnchainSwaps(promise: Promise) {
+        executor.execute {
+            try {
+                getBindingLiquidSdk().rescanOnchainSwaps()
+                promise.resolve(readableMapOf("status" to "ok"))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun sync(promise: Promise) {
         executor.execute {
             try {

--- a/packages/react-native/ios/BreezLiquidSDKMapper.swift
+++ b/packages/react-native/ios/BreezLiquidSDKMapper.swift
@@ -1513,23 +1513,32 @@ enum BreezLiquidSDKMapper {
     }
 
     static func asPrepareRefundResponse(prepareRefundResponse: [String: Any?]) throws -> PrepareRefundResponse {
-        guard let refundTxVsize = prepareRefundResponse["refundTxVsize"] as? UInt32 else {
-            throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "refundTxVsize", typeName: "PrepareRefundResponse"))
+        guard let txVsize = prepareRefundResponse["txVsize"] as? UInt32 else {
+            throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "txVsize", typeName: "PrepareRefundResponse"))
         }
-        guard let refundTxFeeSat = prepareRefundResponse["refundTxFeeSat"] as? UInt64 else {
-            throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "refundTxFeeSat", typeName: "PrepareRefundResponse"))
+        guard let txFeeSat = prepareRefundResponse["txFeeSat"] as? UInt64 else {
+            throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "txFeeSat", typeName: "PrepareRefundResponse"))
+        }
+        var refundTxId: String?
+        if hasNonNilKey(data: prepareRefundResponse, key: "refundTxId") {
+            guard let refundTxIdTmp = prepareRefundResponse["refundTxId"] as? String else {
+                throw LiquidSdkError.Generic(message: errUnexpectedValue(fieldName: "refundTxId"))
+            }
+            refundTxId = refundTxIdTmp
         }
 
         return PrepareRefundResponse(
-            refundTxVsize: refundTxVsize,
-            refundTxFeeSat: refundTxFeeSat
+            txVsize: txVsize,
+            txFeeSat: txFeeSat,
+            refundTxId: refundTxId
         )
     }
 
     static func dictionaryOf(prepareRefundResponse: PrepareRefundResponse) -> [String: Any?] {
         return [
-            "refundTxVsize": prepareRefundResponse.refundTxVsize,
-            "refundTxFeeSat": prepareRefundResponse.refundTxFeeSat,
+            "txVsize": prepareRefundResponse.txVsize,
+            "txFeeSat": prepareRefundResponse.txFeeSat,
+            "refundTxId": prepareRefundResponse.refundTxId == nil ? nil : prepareRefundResponse.refundTxId,
         ]
     }
 

--- a/packages/react-native/ios/BreezLiquidSDKMapper.swift
+++ b/packages/react-native/ios/BreezLiquidSDKMapper.swift
@@ -2803,6 +2803,9 @@ enum BreezLiquidSDKMapper {
         case "refundable":
             return PaymentState.refundable
 
+        case "refundPending":
+            return PaymentState.refundPending
+
         default: throw LiquidSdkError.Generic(message: "Invalid variant \(paymentState) for enum PaymentState")
         }
     }
@@ -2826,6 +2829,9 @@ enum BreezLiquidSDKMapper {
 
         case .refundable:
             return "refundable"
+
+        case .refundPending:
+            return "refundPending"
         }
     }
 

--- a/packages/react-native/ios/RNBreezLiquidSDK.m
+++ b/packages/react-native/ios/RNBreezLiquidSDK.m
@@ -119,6 +119,11 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    rescanOnchainSwaps: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     sync: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/packages/react-native/ios/RNBreezLiquidSDK.swift
+++ b/packages/react-native/ios/RNBreezLiquidSDK.swift
@@ -294,6 +294,16 @@ class RNBreezLiquidSDK: RCTEventEmitter {
         }
     }
 
+    @objc(rescanOnchainSwaps:reject:)
+    func rescanOnchainSwaps(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            try getBindingLiquidSdk().rescanOnchainSwaps()
+            resolve(["status": "ok"])
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(sync:reject:)
     func sync(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -219,8 +219,9 @@ export interface PrepareRefundRequest {
 }
 
 export interface PrepareRefundResponse {
-    refundTxVsize: number
-    refundTxFeeSat: number
+    txVsize: number
+    txFeeSat: number
+    refundTxId?: string
 }
 
 export interface PrepareSendRequest {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -580,6 +580,10 @@ export const refund = async (req: RefundRequest): Promise<RefundResponse> => {
     return response
 }
 
+export const rescanOnchainSwaps = async (): Promise<void> => {
+    await BreezLiquidSDK.rescanOnchainSwaps()
+}
+
 export const sync = async (): Promise<void> => {
     await BreezLiquidSDK.sync()
 }

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -444,7 +444,8 @@ export enum PaymentState {
     COMPLETE = "complete",
     FAILED = "failed",
     TIMED_OUT = "timedOut",
-    REFUNDABLE = "refundable"
+    REFUNDABLE = "refundable",
+    REFUND_PENDING = "refundPending"
 }
 
 export enum PaymentType {


### PR DESCRIPTION
This PR adds monitoring of the lockup addresses of incoming chain swaps, to check the state of any unspent funds for the swap lockup address after the swap is finished. It will periodically:
- For every swap with a pending refund tx, check if the lockup address has any unspent outputs. If there are non, sets the swap to Failed/Complete.
- For every swap that is expired, check if the lockup address has any confirmed unspent outputs for a month (4320 blocks). If there are some, sets the swap to Refundable.

In addition the `prepare_refund` / `refund` interface is updated to allow multiple refunds of a swap (after swap the locktime).

The RefundPending state is added to help differentiate between a pending succeeding swap and a failed swap being refunded.

Fixes #324 