### PR TITLE
Use lowball fees only on lockup and cooperative refund

### DIFF
--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -71,6 +71,13 @@ impl Config {
         self.zero_conf_max_amount_sat
             .unwrap_or(DEFAULT_ZERO_CONF_MAX_SAT)
     }
+
+    pub(crate) fn lowball_fee_rate(&self) -> Option<f32> {
+        match self.network {
+            LiquidNetwork::Mainnet => Some(LOWBALL_FEE_RATE_SAT_PER_VBYTE * 1000.0),
+            LiquidNetwork::Testnet => None,
+        }
+    }
 }
 
 /// Network chosen for this Liquid SDK instance. Note that it represents both the Liquid and the

--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -13,7 +13,7 @@ use tokio::sync::{broadcast, Mutex};
 
 use crate::chain::liquid::LiquidChainService;
 use crate::model::PaymentState::{Complete, Created, Failed, Pending, Refundable, TimedOut};
-use crate::model::{Config, SendSwap, LOWBALL_FEE_RATE_SAT_PER_VBYTE};
+use crate::model::{Config, SendSwap};
 use crate::swapper::Swapper;
 use crate::wallet::OnchainWallet;
 use crate::{ensure_sdk, get_invoice_amount};
@@ -196,7 +196,7 @@ impl SendSwapStateHandler {
         let lockup_tx = self
             .onchain_wallet
             .build_tx(
-                Some(LOWBALL_FEE_RATE_SAT_PER_VBYTE * 1000.0),
+                self.config.lowball_fee_rate(),
                 &create_response.address,
                 create_response.expected_amount,
             )


### PR DESCRIPTION
This fixes a regression introduced in HybridChainService PR where the non cooperative refund also used the lowball fee rate.
Also fixes the broadcast and script_history of chain service on testnet.