### PR TITLE
Added `just` recipe that installs SDK requirements

### DIFF
--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -81,6 +81,10 @@ init *args:
 	melos bootstrap {{args}}
 	melos pub-upgrade
 
+# Install Breez Liquid SDK dependencies
+init-sdk:
+	brew install protobuf
+
 # (melos) Generate docs for packages in workspace
 docs:
 	melos docs


### PR DESCRIPTION
This PR adds `just init-sdk` recipe to install Breez Liquid SDK requirements which will be used on CI runners.