### PR TITLE
Update boltz-client

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -483,13 +483,14 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/dangeross/boltz-rust?branch=savage-chain-swaps#0b6874c12332206b9821734561d4a140f6c0cfbb"
+source = "git+https://github.com/dangeross/boltz-rust?branch=savage-chain-swaps#758d2057f0659014906cd12f89ebf29a03d3d732"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",
  "electrum-client",
  "elements",
  "env_logger 0.7.1",
+ "hex",
  "lightning-invoice 0.30.0",
  "log",
  "native-tls",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -603,13 +603,14 @@ checksum = "829a082bd3761fde7476dc2ed85ca56c11628948460ece621e4f56fef5046567"
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/dangeross/boltz-rust?branch=savage-chain-swaps#0b6874c12332206b9821734561d4a140f6c0cfbb"
+source = "git+https://github.com/dangeross/boltz-rust?branch=savage-chain-swaps#758d2057f0659014906cd12f89ebf29a03d3d732"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",
  "electrum-client",
  "elements",
  "env_logger 0.7.1",
+ "hex",
  "lightning-invoice 0.30.0",
  "log",
  "native-tls",

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -432,12 +432,12 @@ impl ChainSwap {
         let our_pubkey = self.get_claim_keypair()?.public_key();
         let swap_script = match self.direction {
             Direction::Incoming => SwapScriptV2::Liquid(LBtcSwapScriptV2::chain_from_swap_resp(
-                Side::To,
+                Side::Claim,
                 chain_swap_details,
                 our_pubkey.into(),
             )?),
             Direction::Outgoing => SwapScriptV2::Bitcoin(BtcSwapScriptV2::chain_from_swap_resp(
-                Side::To,
+                Side::Claim,
                 chain_swap_details,
                 our_pubkey.into(),
             )?),
@@ -450,12 +450,12 @@ impl ChainSwap {
         let our_pubkey = self.get_refund_keypair()?.public_key();
         let swap_script = match self.direction {
             Direction::Incoming => SwapScriptV2::Bitcoin(BtcSwapScriptV2::chain_from_swap_resp(
-                Side::From,
+                Side::Lockup,
                 chain_swap_details,
                 our_pubkey.into(),
             )?),
             Direction::Outgoing => SwapScriptV2::Liquid(LBtcSwapScriptV2::chain_from_swap_resp(
-                Side::From,
+                Side::Lockup,
                 chain_swap_details,
                 our_pubkey.into(),
             )?),

--- a/lib/core/src/swapper/mod.rs
+++ b/lib/core/src/swapper/mod.rs
@@ -273,12 +273,12 @@ impl BoltzSwapper {
 
         let claim_tx_details = self.client.get_chain_claim_tx_details(&swap.id)?;
         match swap.direction {
-            Direction::Incoming => refund_tx_wrapper.as_bitcoin_tx()?.partial_sig(
+            Direction::Incoming => refund_tx_wrapper.as_bitcoin_tx()?.partial_sign(
                 &refund_keypair,
                 &claim_tx_details.pub_nonce,
                 &claim_tx_details.transaction_hash,
             ),
-            Direction::Outgoing => refund_tx_wrapper.as_liquid_tx()?.partial_sig(
+            Direction::Outgoing => refund_tx_wrapper.as_liquid_tx()?.partial_sign(
                 &refund_keypair,
                 &claim_tx_details.pub_nonce,
                 &claim_tx_details.transaction_hash,
@@ -670,7 +670,7 @@ impl Swapper for BoltzSwapper {
 
         self.validate_send_swap_preimage(swap_id, &swap.invoice, &claim_tx_response.preimage)?;
 
-        let (partial_sig, pub_nonce) = refund_tx.partial_sig(
+        let (partial_sig, pub_nonce) = refund_tx.partial_sign(
             &keypair,
             &claim_tx_response.pub_nonce,
             &claim_tx_response.transaction_hash,


### PR DESCRIPTION
This PR updates the boltz-client dependency, it's now using the merged upstream chain swaps code