### PR TITLE
Receive onchain: add min/max amount to prepare response

### DIFF
--- a/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
+++ b/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
@@ -117,6 +117,8 @@ typedef struct wire_cst_prepare_send_request {
 typedef struct wire_cst_prepare_receive_onchain_response {
   uint64_t amount_sat;
   uint64_t fees_sat;
+  uint64_t min_payer_amount_sat;
+  uint64_t max_payer_amount_sat;
 } wire_cst_prepare_receive_onchain_response;
 
 typedef struct wire_cst_receive_onchain_request {

--- a/lib/bindings/src/breez_liquid_sdk.udl
+++ b/lib/bindings/src/breez_liquid_sdk.udl
@@ -356,6 +356,8 @@ dictionary PrepareReceiveOnchainRequest {
 dictionary PrepareReceiveOnchainResponse {
     u64 amount_sat;
     u64 fees_sat;
+    u64 min_payer_amount_sat;
+    u64 max_payer_amount_sat;
 };
 
 dictionary ReceiveOnchainRequest {

--- a/lib/core/src/frb_generated.io.rs
+++ b/lib/core/src/frb_generated.io.rs
@@ -1161,6 +1161,8 @@ impl CstDecode<crate::model::PrepareReceiveOnchainResponse>
         crate::model::PrepareReceiveOnchainResponse {
             amount_sat: self.amount_sat.cst_decode(),
             fees_sat: self.fees_sat.cst_decode(),
+            min_payer_amount_sat: self.min_payer_amount_sat.cst_decode(),
+            max_payer_amount_sat: self.max_payer_amount_sat.cst_decode(),
         }
     }
 }
@@ -1920,6 +1922,8 @@ impl NewWithNullPtr for wire_cst_prepare_receive_onchain_response {
         Self {
             amount_sat: Default::default(),
             fees_sat: Default::default(),
+            min_payer_amount_sat: Default::default(),
+            max_payer_amount_sat: Default::default(),
         }
     }
 }
@@ -3558,6 +3562,8 @@ pub struct wire_cst_prepare_receive_onchain_request {
 pub struct wire_cst_prepare_receive_onchain_response {
     amount_sat: u64,
     fees_sat: u64,
+    min_payer_amount_sat: u64,
+    max_payer_amount_sat: u64,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -2804,9 +2804,13 @@ impl SseDecode for crate::model::PrepareReceiveOnchainResponse {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_amountSat = <u64>::sse_decode(deserializer);
         let mut var_feesSat = <u64>::sse_decode(deserializer);
+        let mut var_minPayerAmountSat = <u64>::sse_decode(deserializer);
+        let mut var_maxPayerAmountSat = <u64>::sse_decode(deserializer);
         return crate::model::PrepareReceiveOnchainResponse {
             amount_sat: var_amountSat,
             fees_sat: var_feesSat,
+            min_payer_amount_sat: var_minPayerAmountSat,
+            max_payer_amount_sat: var_maxPayerAmountSat,
         };
     }
 }
@@ -4217,6 +4221,8 @@ impl flutter_rust_bridge::IntoDart for crate::model::PrepareReceiveOnchainRespon
         [
             self.amount_sat.into_into_dart().into_dart(),
             self.fees_sat.into_into_dart().into_dart(),
+            self.min_payer_amount_sat.into_into_dart().into_dart(),
+            self.max_payer_amount_sat.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -5586,6 +5592,8 @@ impl SseEncode for crate::model::PrepareReceiveOnchainResponse {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.amount_sat, serializer);
         <u64>::sse_encode(self.fees_sat, serializer);
+        <u64>::sse_encode(self.min_payer_amount_sat, serializer);
+        <u64>::sse_encode(self.max_payer_amount_sat, serializer);
     }
 }
 

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -225,6 +225,10 @@ pub struct PrepareReceiveOnchainRequest {
 pub struct PrepareReceiveOnchainResponse {
     pub amount_sat: u64,
     pub fees_sat: u64,
+    /// Minimum amount of sats the Payer should send
+    pub min_payer_amount_sat: u64,
+    /// Maximum amount of sats the Payer should send
+    pub max_payer_amount_sat: u64,
 }
 
 #[derive(Debug, Serialize)]

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1208,8 +1208,8 @@ impl LiquidSdk {
         Ok(PrepareReceiveOnchainResponse {
             amount_sat,
             fees_sat: pair.fees.boltz(amount_sat) + claim_fees_sat + server_fees_sat,
-            min_payer_amount_sat: pair.limits.maximal,
-            max_payer_amount_sat: pair.limits.minimal,
+            min_payer_amount_sat: pair.limits.minimal,
+            max_payer_amount_sat: pair.limits.maximal,
         })
     }
 

--- a/lib/core/src/sdk.rs
+++ b/lib/core/src/sdk.rs
@@ -1208,6 +1208,8 @@ impl LiquidSdk {
         Ok(PrepareReceiveOnchainResponse {
             amount_sat,
             fees_sat: pair.fees.boltz(amount_sat) + claim_fees_sat + server_fees_sat,
+            min_payer_amount_sat: pair.limits.maximal,
+            max_payer_amount_sat: pair.limits.minimal,
         })
     }
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -2025,10 +2025,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PrepareReceiveOnchainResponse dco_decode_prepare_receive_onchain_response(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2) throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return PrepareReceiveOnchainResponse(
       amountSat: dco_decode_u_64(arr[0]),
       feesSat: dco_decode_u_64(arr[1]),
+      minPayerAmountSat: dco_decode_u_64(arr[2]),
+      maxPayerAmountSat: dco_decode_u_64(arr[3]),
     );
   }
 
@@ -3434,7 +3436,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_amountSat = sse_decode_u_64(deserializer);
     var var_feesSat = sse_decode_u_64(deserializer);
-    return PrepareReceiveOnchainResponse(amountSat: var_amountSat, feesSat: var_feesSat);
+    var var_minPayerAmountSat = sse_decode_u_64(deserializer);
+    var var_maxPayerAmountSat = sse_decode_u_64(deserializer);
+    return PrepareReceiveOnchainResponse(
+        amountSat: var_amountSat,
+        feesSat: var_feesSat,
+        minPayerAmountSat: var_minPayerAmountSat,
+        maxPayerAmountSat: var_maxPayerAmountSat);
   }
 
   @protected
@@ -4756,6 +4764,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.amountSat, serializer);
     sse_encode_u_64(self.feesSat, serializer);
+    sse_encode_u_64(self.minPayerAmountSat, serializer);
+    sse_encode_u_64(self.maxPayerAmountSat, serializer);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -2152,6 +2152,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       PrepareReceiveOnchainResponse apiObj, wire_cst_prepare_receive_onchain_response wireObj) {
     wireObj.amount_sat = cst_encode_u_64(apiObj.amountSat);
     wireObj.fees_sat = cst_encode_u_64(apiObj.feesSat);
+    wireObj.min_payer_amount_sat = cst_encode_u_64(apiObj.minPayerAmountSat);
+    wireObj.max_payer_amount_sat = cst_encode_u_64(apiObj.maxPayerAmountSat);
   }
 
   @protected
@@ -4042,6 +4044,12 @@ final class wire_cst_prepare_receive_onchain_response extends ffi.Struct {
 
   @ffi.Uint64()
   external int fees_sat;
+
+  @ffi.Uint64()
+  external int min_payer_amount_sat;
+
+  @ffi.Uint64()
+  external int max_payer_amount_sat;
 }
 
 final class wire_cst_receive_onchain_request extends ffi.Struct {

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -486,13 +486,22 @@ class PrepareReceiveOnchainResponse {
   final BigInt amountSat;
   final BigInt feesSat;
 
+  /// Minimum amount of sats the Payer should send
+  final BigInt minPayerAmountSat;
+
+  /// Maximum amount of sats the Payer should send
+  final BigInt maxPayerAmountSat;
+
   const PrepareReceiveOnchainResponse({
     required this.amountSat,
     required this.feesSat,
+    required this.minPayerAmountSat,
+    required this.maxPayerAmountSat,
   });
 
   @override
-  int get hashCode => amountSat.hashCode ^ feesSat.hashCode;
+  int get hashCode =>
+      amountSat.hashCode ^ feesSat.hashCode ^ minPayerAmountSat.hashCode ^ maxPayerAmountSat.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -500,7 +509,9 @@ class PrepareReceiveOnchainResponse {
       other is PrepareReceiveOnchainResponse &&
           runtimeType == other.runtimeType &&
           amountSat == other.amountSat &&
-          feesSat == other.feesSat;
+          feesSat == other.feesSat &&
+          minPayerAmountSat == other.minPayerAmountSat &&
+          maxPayerAmountSat == other.maxPayerAmountSat;
 }
 
 class PrepareReceiveRequest {

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1354,6 +1354,12 @@ final class wire_cst_prepare_receive_onchain_response extends ffi.Struct {
 
   @ffi.Uint64()
   external int fees_sat;
+
+  @ffi.Uint64()
+  external int min_payer_amount_sat;
+
+  @ffi.Uint64()
+  external int max_payer_amount_sat;
 }
 
 final class wire_cst_receive_onchain_request extends ffi.Struct {

--- a/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKMapper.kt
@@ -1147,6 +1147,8 @@ fun asPrepareReceiveOnchainResponse(prepareReceiveOnchainResponse: ReadableMap):
             arrayOf(
                 "amountSat",
                 "feesSat",
+                "minPayerAmountSat",
+                "maxPayerAmountSat",
             ),
         )
     ) {
@@ -1154,9 +1156,13 @@ fun asPrepareReceiveOnchainResponse(prepareReceiveOnchainResponse: ReadableMap):
     }
     val amountSat = prepareReceiveOnchainResponse.getDouble("amountSat").toULong()
     val feesSat = prepareReceiveOnchainResponse.getDouble("feesSat").toULong()
+    val minPayerAmountSat = prepareReceiveOnchainResponse.getDouble("minPayerAmountSat").toULong()
+    val maxPayerAmountSat = prepareReceiveOnchainResponse.getDouble("maxPayerAmountSat").toULong()
     return PrepareReceiveOnchainResponse(
         amountSat,
         feesSat,
+        minPayerAmountSat,
+        maxPayerAmountSat,
     )
 }
 
@@ -1164,6 +1170,8 @@ fun readableMapOf(prepareReceiveOnchainResponse: PrepareReceiveOnchainResponse):
     readableMapOf(
         "amountSat" to prepareReceiveOnchainResponse.amountSat,
         "feesSat" to prepareReceiveOnchainResponse.feesSat,
+        "minPayerAmountSat" to prepareReceiveOnchainResponse.minPayerAmountSat,
+        "maxPayerAmountSat" to prepareReceiveOnchainResponse.maxPayerAmountSat,
     )
 
 fun asPrepareReceiveOnchainResponseList(arr: ReadableArray): List<PrepareReceiveOnchainResponse> {

--- a/packages/react-native/ios/BreezLiquidSDKMapper.swift
+++ b/packages/react-native/ios/BreezLiquidSDKMapper.swift
@@ -1368,10 +1368,18 @@ enum BreezLiquidSDKMapper {
         guard let feesSat = prepareReceiveOnchainResponse["feesSat"] as? UInt64 else {
             throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "feesSat", typeName: "PrepareReceiveOnchainResponse"))
         }
+        guard let minPayerAmountSat = prepareReceiveOnchainResponse["minPayerAmountSat"] as? UInt64 else {
+            throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "minPayerAmountSat", typeName: "PrepareReceiveOnchainResponse"))
+        }
+        guard let maxPayerAmountSat = prepareReceiveOnchainResponse["maxPayerAmountSat"] as? UInt64 else {
+            throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "maxPayerAmountSat", typeName: "PrepareReceiveOnchainResponse"))
+        }
 
         return PrepareReceiveOnchainResponse(
             amountSat: amountSat,
-            feesSat: feesSat
+            feesSat: feesSat,
+            minPayerAmountSat: minPayerAmountSat,
+            maxPayerAmountSat: maxPayerAmountSat
         )
     }
 
@@ -1379,6 +1387,8 @@ enum BreezLiquidSDKMapper {
         return [
             "amountSat": prepareReceiveOnchainResponse.amountSat,
             "feesSat": prepareReceiveOnchainResponse.feesSat,
+            "minPayerAmountSat": prepareReceiveOnchainResponse.minPayerAmountSat,
+            "maxPayerAmountSat": prepareReceiveOnchainResponse.maxPayerAmountSat,
         ]
     }
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -201,6 +201,8 @@ export interface PrepareReceiveOnchainRequest {
 export interface PrepareReceiveOnchainResponse {
     amountSat: number
     feesSat: number
+    minPayerAmountSat: number
+    maxPayerAmountSat: number
 }
 
 export interface PrepareReceiveRequest {


### PR DESCRIPTION
This brings the Liquid SDK in alignment with the Breez SDK, where the swap info contains the min/max that the payer can send onchain to the SDK.

This also helps make the docs clearer and the UX more user-friendly.