### PR TITLE
Fix `just` recipe args for building binaries for Apple, Android and other platforms

### DIFF
--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -43,14 +43,14 @@ ffigen:
 build *args:
 	cargo build --package breez-liquid-sdk --manifest-path ../../../core/Cargo.toml --features frb {{args}}
 
-build-apple *args:
-	dart scripts/build_apple.dart {{args}}
+build-apple profile='frb-min':
+	dart scripts/build_apple.dart --profile {{profile}}
 
-build-android profile='release':
-	bash scripts/build-android.sh {{profile}}
+build-android profile='frb-min':
+	bash scripts/build-android.sh --profile {{profile}}
 
-build-other *args:
-	dart scripts/build_other.dart {{args}}
+build-other profile='frb-min':
+	dart scripts/build_other.dart --profile {{profile}}
 
 # (melos) Run tests on packages in workspace
 test build='false':

--- a/lib/bindings/langs/flutter/scripts/build-android.sh
+++ b/lib/bindings/langs/flutter/scripts/build-android.sh
@@ -2,7 +2,7 @@
 
 # Setup
 BUILD_DIR=platform-build
-mkdir $BUILD_DIR
+mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
 # Create the jniLibs build directory

--- a/lib/bindings/langs/flutter/scripts/build_other.sh
+++ b/lib/bindings/langs/flutter/scripts/build_other.sh
@@ -4,7 +4,7 @@
 
 # Setup
 BUILD_DIR=platform-build
-mkdir $BUILD_DIR
+mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
 # Install build dependencies
@@ -18,7 +18,7 @@ zig_build () {
     local PROFILE="$4"
     rustup target add "$TARGET"
     cargo zigbuild --package breez-liquid-sdk --target "$TARGET" --profile $PROFILE
-    mkdir "$PLATFORM_NAME"
+    mkdir -p "$PLATFORM_NAME"
     cp "../../../../target/$TARGET/$PROFILE/$LIBNAME" "$PLATFORM_NAME/"
 }
 
@@ -29,7 +29,7 @@ win_build () {
     local PROFILE="$4"
     rustup target add "$TARGET"
     cargo xwin build --package breez-liquid-sdk --target "$TARGET" --profile $PROFILE
-    mkdir "$PLATFORM_NAME"
+    mkdir -p "$PLATFORM_NAME"
     cp "../../../../target/$TARGET/$PROFILE/$LIBNAME" "$PLATFORM_NAME/"
 }
 


### PR DESCRIPTION
This PR fixes the arguments used on non-grouped `just` recipes for building binaries for Apple, Android and other platforms.

#### Other changes:
- Ignore errors and create parent dir's as needed when using `mkdir` command