### PR TITLE
Publish Dart and Flutter packages

### DIFF
--- a/.github/workflows/build-bindings-flutter.yml
+++ b/.github/workflows/build-bindings-flutter.yml
@@ -1,0 +1,110 @@
+name: Build bindings for Flutter
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+      use-dummy-binaries:
+        description: 'If true, creates dummy binaries rather than real binaries'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    if: ${{ !inputs.use-dummy-binaries }}
+    runs-on: macOS-latest
+    name: Build Flutter bindings 
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+      with: 
+        ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository || github.repository }}
+
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v3
+      with:
+        version: "27.2"
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install Zig
+      uses: goto-bus-stop/setup-zig@v2
+        
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: lib
+
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        channel: stable
+    - run: flutter --version
+
+    - name: Set up just
+      uses: extractions/setup-just@v2
+
+    - name: Set up Melos
+      uses: bluefireteam/melos-action@v3
+      with:
+        run-bootstrap: false
+    
+    - name: Initialize the workspace
+      working-directory: lib/bindings/langs/flutter/
+      run: |
+        just clean
+        just init
+    
+    - name: Install flutter_rust_bridge_codegen dependencies
+      working-directory: lib/bindings/langs/flutter/
+      run: just frb
+
+    - name: Build bindings 
+      working-directory: lib/bindings/langs/flutter/
+      run: just build
+
+    - name: Build language packages
+      working-directory: lib/bindings/langs/flutter/
+      run: melos build
+
+    - name: Copy build output
+      run: |
+        mkdir -p dist
+        cp lib/bindings/flutter/platform-build/android.tar.gz dist
+        cp lib/bindings/flutter/platform-build/breez_liquid_sdk.xcframework.zip dist
+        cp lib/bindings/flutter/platform-build/other.tar.gz dist
+
+    - name: Archive Flutter bindings
+      uses: actions/upload-artifact@v3
+      with:
+        name: bindings-flutter
+        path: dist/*
+
+  build-dummies:
+    if: ${{ inputs.use-dummy-binaries }}
+    runs-on: macOS-latest
+    name: Build Flutter dummy bindings
+    steps:
+      - name: Create dummy files
+        run: |
+          touch android.tar.gz
+          touch breez_liquid_sdk.xcframework.zip
+          touch other.tar.gz
+
+      - name: Archive Flutter dummy bindings
+        uses: actions/upload-artifact@v3
+        with:
+          name: bindings-flutter
+          path: ./*

--- a/.github/workflows/build-bindings-flutter.yml
+++ b/.github/workflows/build-bindings-flutter.yml
@@ -82,9 +82,9 @@ jobs:
     - name: Copy build output
       run: |
         mkdir -p dist
-        cp lib/bindings/flutter/platform-build/android.tar.gz dist
-        cp lib/bindings/flutter/platform-build/breez_liquid_sdk.xcframework.zip dist
-        cp lib/bindings/flutter/platform-build/other.tar.gz dist
+        cp lib/bindings/langs/flutter/platform-build/android.tar.gz dist
+        cp lib/bindings/langs/flutter/platform-build/breez_liquid_sdk.xcframework.zip dist
+        cp lib/bindings/langs/flutter/platform-build/other.tar.gz dist
 
     - name: Archive Flutter bindings
       uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -286,6 +286,7 @@ jobs:
       publish: ${{ needs.setup.outputs.publish == 'true' }}
     secrets:
       REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
+      SWIFT_RELEASE_TOKEN: ${{ secrets.SWIFT_RELEASE_TOKEN }}
 
   # react native version x.y.z will at runtime require
   # ios and android packages x.y.z being published already.

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -98,6 +98,7 @@ jobs:
       bindings-windows: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version }}
       bindings-darwin: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version || !!needs.pre-setup.outputs.swift-package-version }}
       bindings-linux: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version }}
+      bindings-flutter: ${{ !!needs.pre-setup.outputs.flutter-package-version }}
       bindings-android: ${{ !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.golang-package-version }}
       bindings-ios: ${{ !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.swift-package-version }}
       kotlin: ${{ !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.flutter-package-version }}
@@ -146,6 +147,15 @@ jobs:
     needs: setup
     if: ${{ needs.setup.outputs.bindings-linux == 'true' }}
     uses: ./.github/workflows/build-bindings-linux.yml
+    with:
+      repository: ${{ needs.setup.outputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}
+      use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
+
+  build-bindings-flutter:
+    needs: setup
+    if: ${{ needs.setup.outputs.bindings-flutter == 'true' }}
+    uses: ./.github/workflows/build-bindings-flutter.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
@@ -248,20 +258,20 @@ jobs:
     secrets:
       BREEZ_MVN_USERNAME: ${{ secrets.BREEZ_MVN_USERNAME }}
       BREEZ_MVN_PASSWORD: ${{ secrets.BREEZ_MVN_PASSWORD }}
-  
-#  publish-flutter:
-#    needs:
-#      - setup
-#      - build-language-bindings
-#    if: ${{ needs.setup.outputs.flutter == 'true' }}
-#    uses: ./.github/workflows/publish-flutter.yml
-#    with:
-#      repository: ${{ needs.setup.outputs.repository }}
-#      ref: ${{ needs.setup.outputs.ref }}
-#      package-version: ${{ needs.setup.outputs.flutter-package-version }}
-#      publish: ${{ needs.setup.outputs.publish == 'true' }}
-#    secrets:
-#      REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
+    
+  publish-flutter:
+    needs:
+      - setup
+      - build-bindings-flutter
+    if: ${{ needs.setup.outputs.flutter == 'true' }}
+    uses: ./.github/workflows/publish-flutter.yml
+    with:
+      repository: ${{ needs.setup.outputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}
+      package-version: ${{ needs.setup.outputs.flutter-package-version }}
+      publish: ${{ needs.setup.outputs.publish == 'true' }}
+    secrets:
+      REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
 
   # react native version x.y.z will at runtime require
   # ios and android packages x.y.z being published already.

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -208,6 +208,19 @@ jobs:
 #      skip-tests: true
 #    secrets:
 #      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    
+  publish-dart:
+    needs:
+      - setup
+    if: ${{ needs.setup.outputs.flutter == 'true' }}
+    uses: ./.github/workflows/publish-dart.yml
+    with:
+      repository: ${{ needs.setup.outputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}
+      package-version: ${{ needs.setup.outputs.flutter-package-version }}
+      publish: ${{ needs.setup.outputs.publish == 'true' }}
+    secrets:
+      REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
 #
 #  publish-golang:
 #    needs:
@@ -263,6 +276,7 @@ jobs:
     needs:
       - setup
       - build-bindings-flutter
+      - publish-dart
     if: ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml
     with:

--- a/.github/workflows/publish-dart.yml
+++ b/.github/workflows/publish-dart.yml
@@ -1,0 +1,85 @@
+name: Publish Dart Package
+on:   
+  workflow_call:
+    inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+      package-version:
+        description: 'version for the dart package (MAJOR.MINOR.BUILD) (no v prefix)'
+        required: true
+        type: string
+      publish:
+        description: 'value indicating whether to commit/tag a release.'
+        required: true
+        type: boolean
+        default: true
+    secrets:
+      REPO_SSH_KEY:
+        description: 'ssh key to commit to the breez-liquid-sdk-dart repository'
+        required: true
+
+jobs:
+  build-tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout breez-liquid-sdk-dart repo
+        uses: actions/checkout@v3
+        with:
+          repository: breez/breez-liquid-sdk-dart
+          ssh-key: ${{ secrets.REPO_SSH_KEY }}
+          fetch-depth: 0
+          path: dist
+
+      - name: Checkout breez-liquid-sdk repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.sha }}
+          path: build
+
+      - name: Copy package files
+        working-directory: dist
+        run: |
+          rm -r lib
+          cp -r ../build/packages/dart/lib .
+          cp ../build/packages/dart/analysis_options.yaml .
+          cp ../build/packages/dart/pubspec.yaml .
+          cp ../build/packages/dart/pubspec.lock .
+
+      - name: Copy docs
+        working-directory: dist
+        run: |
+          cp ../build/packages/dart/README.md . || true
+          cp ../build/packages/dart/CHANGELOG.md . || true
+
+      - name: Set package version
+        working-directory: dist
+        run: |
+          sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
+          rm pubspec.yaml.bak
+
+      - name: Archive Dart release
+        uses: actions/upload-artifact@v3
+        with:
+          name: breez-liquid-sdk-dart-${{ inputs.package-version || github.sha }}
+          path: |
+            dist/*
+            !dist/.git
+
+      - name: Tag the Dart package
+        working-directory: dist
+        if: ${{ inputs.publish }}
+        run: |
+          git config --global user.email github-actions@github.com
+          git config --global user.name github-actions
+          git add .
+          git commit -m "Update Dart package to version v${{ inputs.package-version }}"
+          git push
+          git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
+          git push --tags

--- a/.github/workflows/publish-dart.yml
+++ b/.github/workflows/publish-dart.yml
@@ -50,7 +50,6 @@ jobs:
           cp -r ../build/packages/dart/lib .
           cp ../build/packages/dart/analysis_options.yaml .
           cp ../build/packages/dart/pubspec.yaml .
-          cp ../build/packages/dart/pubspec.lock .
 
       - name: Copy docs
         working-directory: dist

--- a/.github/workflows/publish-dart.yml
+++ b/.github/workflows/publish-dart.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Copy package files
         working-directory: dist
         run: |
-          rm -r lib
+          rm -rf lib
           cp -r ../build/packages/dart/lib .
           cp ../build/packages/dart/analysis_options.yaml .
           cp ../build/packages/dart/pubspec.yaml .

--- a/.github/workflows/publish-dart.yml
+++ b/.github/workflows/publish-dart.yml
@@ -55,8 +55,9 @@ jobs:
       - name: Copy docs
         working-directory: dist
         run: |
-          cp ../build/packages/dart/README.md . || true
           cp ../build/packages/dart/CHANGELOG.md . || true
+          cp ../build/packages/dart/LICENSE . || true
+          cp ../build/packages/dart/README.md . || true
 
       - name: Set package version
         working-directory: dist

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -81,8 +81,8 @@ jobs:
           sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
           sed -i.bak -e 's/path:.*/git:\n      url: git@github.com:breez\/breez-liquid-sdk-dart.git\n      ref: ${{ inputs.package-version }}/' pubspec_overrides.yaml
           sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
-          sed -i.bak -e 's/set(TagName.*/set(TagName "${{ inputs.package-version }}")/' android/CMakeLists.txt
-          sed -i.bak -e "s/^tag_name = .*/tag_name = '${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
+          sed -i.bak -e 's/set(TagName.*/set(TagName "v${{ inputs.package-version }}")/' android/CMakeLists.txt
+          sed -i.bak -e "s/^tag_name = .*/tag_name = 'v${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
           rm pubspec.yaml.bak
           rm pubspec_overrides.yaml.bak
           rm android/build.gradle.bak

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -64,8 +64,9 @@ jobs:
       - name: Copy docs
         working-directory: dist
         run: |
-          cp ../build/packages/flutter/README.md . || true
           cp ../build/packages/flutter/CHANGELOG.md . || true
+          cp ../build/packages/flutter/LICENSE . || true
+          cp ../build/packages/flutter/README.md . || true
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -82,7 +82,7 @@ jobs:
           rm pubspec.yaml.bak
           rm pubspec_overrides.yaml.bak
           rm android/build.gradle.bak
-          rm ios/breez_liquid_sdk.podspec.bak
+          rm ios/flutter_breez_liquid.podspec.bak
 
       - name: Archive flutter release
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -79,7 +79,7 @@ jobs:
         working-directory: dist
         run: |
           sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
-          sed -i.bak -e 's/path:.*/git:\n\t\t\turl: git@github.com:breez\/breez-liquid-sdk-dart.git\n\t\t\tref: ${{ inputs.package-version }}/' pubspec_overrides.yaml
+          sed -i.bak -e 's/path:.*/git:\n      url: git@github.com:breez\/breez-liquid-sdk-dart.git\n      ref: ${{ inputs.package-version }}/' pubspec_overrides.yaml
           sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
           sed -i.bak -e "s/^tag_name = .*/tag_name = '${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
           rm pubspec.yaml.bak

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -59,7 +59,6 @@ jobs:
           cp ../build/packages/flutter/analysis_options.yaml .
           cp ../build/packages/flutter/pubspec.yaml .
           cp ../build/packages/flutter/pubspec_overrides.yaml .
-          cp ../build/packages/flutter/pubspec.lock .
 
       - name: Copy docs
         working-directory: dist

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -59,6 +59,7 @@ jobs:
           cp -r ../build/packages/flutter/android .
           cp -r ../build/packages/flutter/ios .
           cp -r ../build/packages/flutter/lib .
+          cp -r ../build/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h ios/Classes
           cp ../build/packages/flutter/analysis_options.yaml .
           cp ../build/packages/flutter/pubspec.yaml .
           cp ../build/packages/flutter/pubspec_overrides.yaml .

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -23,6 +23,9 @@ on:
       REPO_SSH_KEY:
         description: 'ssh key to commit to the breez-liquid-sdk-flutter repository'
         required: true
+      SWIFT_RELEASE_TOKEN:
+        description: 'github token to release to the breez-liquid-sdk-flutter repository'
+        required: true
 
 jobs:
   build-tag-release:

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -118,7 +118,7 @@ jobs:
             bindings/android.tar.gz
             bindings/breez_liquid_sdk.xcframework.zip
             bindings/other.tar.gz
-          tag_name: ${{ inputs.package-version || '0.0.1' }}
+          tag_name: v${{ inputs.package-version || '0.0.1' }}
           generate_release_notes: false
           token: ${{ secrets.SWIFT_RELEASE_TOKEN }}
           prerelease: true

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -53,33 +53,31 @@ jobs:
           rm -r ios
           rm -r android
           rm -r lib
-          cp -r ../build/lib/bindings/langs/flutter/ios .
-          mv ios/breez_liquid_sdk.podspec.production ios/breez_liquid_sdk.podspec
-          cp -r ../build/lib/bindings/langs/flutter/android .
-          mv langs/android/build.gradle.production langs/android/build.gradle
-          cp -r ../build/lib/bindings/langs/flutter/lib .
-          cp ../build/lib/bindings/langs/flutter/pubspec.yaml .
-          cp ../build/lib/bindings/langs/flutter/pubspec.lock .
+          cp -r ../build/packages/flutter/ios .
+          cp -r ../build/packages/flutter/android .
+          cp -r ../build/packages/flutter/lib .
+          cp ../build/packages/flutter/pubspec.yaml .
+          cp ../build/packages/flutter/pubspec.lock .
 
       - name: Copy docs
         working-directory: dist
         run: |
-          cp ../build/lib/bindings/langs/flutter/README.pub.md README.md || true
-          cp ../build/lib/bindings/langs/flutter/CHANGELOG.md . || true
+          cp ../build/packages/flutter/README.md . || true
+          cp ../build/packages/flutter/CHANGELOG.md . || true
 
       - uses: actions/download-artifact@v3
         with:
-          name: bindings-swift
-          path: dist/ios/bindings-swift/Sources/BreezLiquidSDK/
+          name: bindings-flutter
+          path: bindings/
 
       - name: Set package version
         working-directory: dist
         run: |
           sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
-          sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" langs/android/build.gradle
-          sed -i.bak -e "s/^tag_version = .*/tag_version = '${{ inputs.package-version }}'/" ios/breez_liquid_sdk.podspec
+          sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
+          sed -i.bak -e "s/^tag_name = .*/tag_name = '${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
           rm pubspec.yaml.bak
-          rm langs/android/build.gradle.bak
+          rm android/build.gradle.bak
           rm ios/breez_liquid_sdk.podspec.bak
 
       - name: Archive flutter release
@@ -101,3 +99,17 @@ jobs:
           git push
           git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
           git push --tags
+
+      - name: Release and attach binary artifacts
+        if: ${{ inputs.publish }}
+        uses: softprops/action-gh-release@v2
+        with:
+          repository: breez/breez-liquid-sdk-flutter
+          files: |
+            bindings/android.tar.gz
+            bindings/breez_liquid_sdk.xcframework.zip
+            bindings/other.tar.gz
+          tag_name: ${{ inputs.package-version || '0.0.1' }}
+          generate_release_notes: false
+          token: ${{ secrets.SWIFT_RELEASE_TOKEN }}
+          prerelease: true

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -82,7 +82,7 @@ jobs:
           sed -i.bak -e 's/path:.*/git:\n      url: git@github.com:breez\/breez-liquid-sdk-dart.git\n      ref: ${{ inputs.package-version }}/' pubspec_overrides.yaml
           sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
           sed -i.bak -e 's/set(TagName.*/set(TagName "v${{ inputs.package-version }}")/' android/CMakeLists.txt
-          sed -i.bak -e "s/^tag_name = .*/tag_name = 'v${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
+          sed -i.bak -e "s/^version = .*/version = '${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
           rm pubspec.yaml.bak
           rm pubspec_overrides.yaml.bak
           rm android/build.gradle.bak

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Copy package files
         working-directory: dist
         run: |
-          rm -r android
-          rm -r ios
-          rm -r lib
+          rm -rf android
+          rm -rf ios
+          rm -rf lib
           cp -r ../build/packages/flutter/android .
           cp -r ../build/packages/flutter/ios .
           cp -r ../build/packages/flutter/lib .

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -50,13 +50,15 @@ jobs:
       - name: Copy package files
         working-directory: dist
         run: |
-          rm -r ios
           rm -r android
+          rm -r ios
           rm -r lib
-          cp -r ../build/packages/flutter/ios .
           cp -r ../build/packages/flutter/android .
+          cp -r ../build/packages/flutter/ios .
           cp -r ../build/packages/flutter/lib .
+          cp ../build/packages/flutter/analysis_options.yaml .
           cp ../build/packages/flutter/pubspec.yaml .
+          cp ../build/packages/flutter/pubspec_overrides.yaml .
           cp ../build/packages/flutter/pubspec.lock .
 
       - name: Copy docs
@@ -74,9 +76,11 @@ jobs:
         working-directory: dist
         run: |
           sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
+          sed -i.bak -e 's/path:.*/git:\n\t\t\turl: git@github.com:breez\/breez-liquid-sdk-dart.git\n\t\t\tref: ${{ inputs.package-version }}/' pubspec_overrides.yaml
           sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
           sed -i.bak -e "s/^tag_name = .*/tag_name = '${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
           rm pubspec.yaml.bak
+          rm pubspec_overrides.yaml.bak
           rm android/build.gradle.bak
           rm ios/breez_liquid_sdk.podspec.bak
 
@@ -95,7 +99,7 @@ jobs:
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
           git add .
-          git commit -m "Update Breez SDK Flutter package to version v${{ inputs.package-version }}"
+          git commit -m "Update Flutter package to version v${{ inputs.package-version }}"
           git push
           git tag v${{ inputs.package-version }} -m "v${{ inputs.package-version }}"
           git push --tags

--- a/.github/workflows/publish-flutter.yml
+++ b/.github/workflows/publish-flutter.yml
@@ -81,10 +81,12 @@ jobs:
           sed -i.bak -e 's/version:.*/version: ${{ inputs.package-version }}/' pubspec.yaml
           sed -i.bak -e 's/path:.*/git:\n      url: git@github.com:breez\/breez-liquid-sdk-dart.git\n      ref: ${{ inputs.package-version }}/' pubspec_overrides.yaml
           sed -i.bak -e "s/^version .*/version '${{ inputs.package-version }}'/" android/build.gradle
+          sed -i.bak -e 's/set(TagName.*/set(TagName "${{ inputs.package-version }}")/' android/CMakeLists.txt
           sed -i.bak -e "s/^tag_name = .*/tag_name = '${{ inputs.package-version }}'/" ios/flutter_breez_liquid.podspec
           rm pubspec.yaml.bak
           rm pubspec_overrides.yaml.bak
           rm android/build.gradle.bak
+          rm android/CMakeLists.txt.bak
           rm ios/flutter_breez_liquid.podspec.bak
 
       - name: Archive flutter release

--- a/lib/bindings/langs/flutter/justfile
+++ b/lib/bindings/langs/flutter/justfile
@@ -1,4 +1,4 @@
-curr_version := "breez_liquid-v" + `awk '/^version: /{print $2}' ../../../../packages/dart/pubspec.yaml`
+curr_version := "breez_liquid-v" + `awk '/^version: /{print $2}' ../../../../packages/flutter/pubspec.yaml`
 frb_bin := "flutter_rust_bridge_codegen generate"
 
 export CARGO_TERM_COLOR := "always"

--- a/lib/bindings/langs/flutter/pubspec.lock
+++ b/lib/bindings/langs/flutter/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   conventional_commit:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "40f592dd352890c3b60fec1b68e786cefb9603e05ff303dbc4dda49b304ecdf4"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   io:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   pool:
     dependency: transitive
     description:
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:

--- a/lib/bindings/langs/flutter/scripts/version.sh
+++ b/lib/bindings/langs/flutter/scripts/version.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 ROOT="../../../.."
-TAG_NAME=v`awk '/^version: /{print $2}' $ROOT/packages/flutter/pubspec.yaml`
+TAG_NAME=`awk '/^version: /{print $2}' $ROOT/packages/flutter/pubspec.yaml`
 
 # iOS & macOS
-APPLE_HEADER="tag_name = '$TAG_NAME' # generated; do not edit"
+APPLE_HEADER="version = '$TAG_NAME' # generated; do not edit"
 sed -i.bak "1 s/.*/$APPLE_HEADER/" $ROOT/packages/flutter/ios/flutter_breez_liquid.podspec
 sed -i.bak "1 s/.*/$APPLE_HEADER/" $ROOT/packages/flutter/macos/flutter_breez_liquid.podspec
 rm $ROOT/packages/flutter/macos/*.bak $ROOT/packages/flutter/ios/*.bak
 
 # CMake platforms (Linux, Windows, and Android)
-CMAKE_HEADER="set(TagName \"$TAG_NAME\") # generated; do not edit"
+CMAKE_HEADER="set(TagName \"v$TAG_NAME\") # generated; do not edit"
 for CMAKE_PLATFORM in android linux windows
 do
     sed -i.bak "1 s/.*/$CMAKE_HEADER/" $ROOT/packages/flutter/$CMAKE_PLATFORM/CMakeLists.txt

--- a/lib/bindings/langs/flutter/scripts/version.sh
+++ b/lib/bindings/langs/flutter/scripts/version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ROOT="../../../.."
-TAG_NAME=`awk '/^version: /{print $2}' $ROOT/packages/flutter/pubspec.yaml`
+TAG_NAME=v`awk '/^version: /{print $2}' $ROOT/packages/flutter/pubspec.yaml`
 
 # iOS & macOS
 APPLE_HEADER="tag_name = '$TAG_NAME' # generated; do not edit"

--- a/lib/bindings/langs/flutter/scripts/version.sh
+++ b/lib/bindings/langs/flutter/scripts/version.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-
-CURR_VERSION=breez_liquid-v`awk '/^version: /{print $2}' ../../../packages/dart/pubspec.yaml`
+ROOT="../../../.."
+TAG_NAME=`awk '/^version: /{print $2}' $ROOT/packages/flutter/pubspec.yaml`
 
 # iOS & macOS
-APPLE_HEADER="release_tag_name = '$CURR_VERSION' # generated; do not edit"
-sed -i.bak "1 s/.*/$APPLE_HEADER/" ../../../packages/flutter/ios/flutter_breez_liquid.podspec
-sed -i.bak "1 s/.*/$APPLE_HEADER/" ../../../packages/flutter/macos/flutter_breez_liquid.podspec
-rm ../../../packages/flutter/macos/*.bak ../../../packages/flutter/ios/*.bak
+APPLE_HEADER="tag_name = '$TAG_NAME' # generated; do not edit"
+sed -i.bak "1 s/.*/$APPLE_HEADER/" $ROOT/packages/flutter/ios/flutter_breez_liquid.podspec
+sed -i.bak "1 s/.*/$APPLE_HEADER/" $ROOT/packages/flutter/macos/flutter_breez_liquid.podspec
+rm $ROOT/packages/flutter/macos/*.bak $ROOT/packages/flutter/ios/*.bak
 
 # CMake platforms (Linux, Windows, and Android)
-CMAKE_HEADER="set(LibraryVersion \"$CURR_VERSION\") # generated; do not edit"
+CMAKE_HEADER="set(TagName \"$TAG_NAME\") # generated; do not edit"
 for CMAKE_PLATFORM in android linux windows
 do
-    sed -i.bak "1 s/.*/$CMAKE_HEADER/" ../../../packages/flutter/$CMAKE_PLATFORM/CMakeLists.txt
-    rm ../../../packages/flutter/$CMAKE_PLATFORM/*.bak
+    sed -i.bak "1 s/.*/$CMAKE_HEADER/" $ROOT/packages/flutter/$CMAKE_PLATFORM/CMakeLists.txt
+    rm $ROOT/packages/flutter/$CMAKE_PLATFORM/*.bak
 done
 
-git add ../../../packages/flutter/
+git add $ROOT/packages/flutter/

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -2,7 +2,8 @@ name: breez_liquid
 description: Dart bindings for the Breez Liquid SDK
 version: 0.1.0
 homepage: https://breez.technology
-repository: https://github.com/breez/breez-liquid-sdk
+repository: https://github.com/breez/breez-liquid-sdk-dart
+publish_to: 'none'
 
 platforms:
   macos:

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -3,10 +3,29 @@
 [![pub package](https://img.shields.io/pub/v/breez_liquid_sdk.svg)](https://pub.dev/packages/breez_liquid_sdk)
 
 ## Table of contents
+- [Platform Support](#platform-support)
+- [Requirements](#requirements)
 - [Description](#description)
 - [Installation](#installation)
 - [Usage](#usage)
 - [Documentation](#documentation)
+
+## Platform Support
+
+| Android | iOS | MacOS | Web | Linux | Windows |
+| :-----: | :-: | :---: | :-: | :---: | :----: |
+|   ✅    | ❎  |  ❎   | ❎  |  ❎   |   ❎   |
+
+## Requirements
+
+- Flutter >=3.10.0
+- Dart >=3.4.0 <4.0.0
+- iOS >=12.0
+- MacOS >=10.11
+- Android `compileSDK` 31
+- Java 1.8
+- Android Gradle Plugin >=7.1.2
+- Gradle wrapper >=7.4
 
 ## Description
 

--- a/packages/flutter/android/CMakeLists.txt
+++ b/packages/flutter/android/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(TagName "0.1.0") # generated; do not edit
-set(LibraryVersion "breez_liquid-v${TagName}")
+set(TagName "v0.1.0") # generated; do not edit
+set(LibraryVersion "breez_liquid-${TagName}")
 
 # Unlike the Windows & Linux CMakeLists.txt, this Android equivalent is just here
 # to download the Android binaries into src/main/jniLibs/ and does not build anything.

--- a/packages/flutter/android/CMakeLists.txt
+++ b/packages/flutter/android/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(LibraryVersion "breez_liquid-v0.1.0") # generated; do not edit
+set(TagName "0.1.0") # generated; do not edit
+set(LibraryVersion "breez_liquid-v${TagName}")
 
 # Unlike the Windows & Linux CMakeLists.txt, this Android equivalent is just here
 # to download the Android binaries into src/main/jniLibs/ and does not build anything.
@@ -15,7 +16,7 @@ set(LibRoot "${CMAKE_CURRENT_SOURCE_DIR}/src/main/jniLibs")
 set(ArchivePath "${CMAKE_CURRENT_SOURCE_DIR}/${LibraryVersion}.tar.gz")
 if(NOT EXISTS ${ArchivePath})
   file(DOWNLOAD
-    "https://github.com/breez/breez-liquid-sdk/releases/download/${LibraryVersion}/android.tar.gz"
+    "https://github.com/breez/breez-liquid-sdk-flutter/releases/download/${TagName}/android.tar.gz"
     ${ArchivePath}
     TLS_VERIFY ON
   )

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -527,10 +527,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
   web:
     dependency: transitive
     description:

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -527,10 +527,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:

--- a/packages/flutter/example/pubspec.yaml
+++ b/packages/flutter/example/pubspec.yaml
@@ -12,7 +12,9 @@ dependencies:
     sdk: flutter
 
   flutter_rust_bridge: ^2.0.0
-  flutter_breez_liquid: ^0.1.0
+  flutter_breez_liquid:
+    git:
+      url: https://github.com/breez/breez-liquid-sdk-flutter
   # When depending on this package from a real application you should use:
   #   flutter_breez_liquid: ^x.y.z
   # See https://dart.dev/tools/pub/dependencies#version-constraints

--- a/packages/flutter/ios/flutter_breez_liquid.podspec
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec
@@ -1,10 +1,11 @@
-release_tag_name = 'breez_liquid-v0.1.0' # generated; do not edit
+tag_name = '0.1.0' # generated; do not edit
+release_tag_name = "breez_liquid-v#{tag_name}"
 
 # We cannot distribute the XCFramework alongside the library directly,
 # so we have to fetch the correct version here.
 framework_name = 'breez_liquid_sdk.xcframework'
 remote_zip_name = "#{framework_name}.zip"
-url = "https://github.com/breez/breez-liquid-sdk/releases/download/#{release_tag_name}/#{remote_zip_name}"
+url = "https://github.com/breez/breez-liquid-sdk-flutter/releases/download/#{tag_name}/#{remote_zip_name}.zip"
 local_zip_name = "#{release_tag_name}.zip"
 `
 cd Frameworks
@@ -21,7 +22,7 @@ cd -
 
 Pod::Spec.new do |spec|
   spec.name          = 'flutter_breez_liquid'
-  spec.version       = '0.1.0'
+  spec.version       = "#{tag_name}"
   spec.license       = { :file => '../LICENSE' }
   spec.homepage      = 'https://breez.technology'
   spec.authors       = { 'Breez' => 'contact@breez.technology' }

--- a/packages/flutter/ios/flutter_breez_liquid.podspec
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec
@@ -1,4 +1,5 @@
-tag_name = 'v0.1.0' # generated; do not edit
+version = '0.1.0' # generated; do not edit
+tag_name = "v#{version}"
 release_tag_name = "breez_liquid-#{tag_name}"
 
 # We cannot distribute the XCFramework alongside the library directly,
@@ -10,7 +11,7 @@ local_zip_name = "#{release_tag_name}.zip"
 
 Pod::Spec.new do |spec|
   spec.name          = 'flutter_breez_liquid'
-  spec.version       = "#{tag_name}"
+  spec.version       = "#{version}"
   spec.license       = { :file => '../LICENSE' }
   spec.homepage      = 'https://breez.technology'
   spec.authors       = { 'Breez' => 'contact@breez.technology' }

--- a/packages/flutter/ios/flutter_breez_liquid.podspec
+++ b/packages/flutter/ios/flutter_breez_liquid.podspec
@@ -1,5 +1,5 @@
-tag_name = '0.1.0' # generated; do not edit
-release_tag_name = "breez_liquid-v#{tag_name}"
+tag_name = 'v0.1.0' # generated; do not edit
+release_tag_name = "breez_liquid-#{tag_name}"
 
 # We cannot distribute the XCFramework alongside the library directly,
 # so we have to fetch the correct version here.

--- a/packages/flutter/linux/CMakeLists.txt
+++ b/packages/flutter/linux/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(LibraryVersion "breez_liquid-v0.1.0") # generated; do not edit
+set(TagName "0.1.0") # generated; do not edit
+set(LibraryVersion "breez_liquid-v${TagName}")
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause
@@ -14,7 +15,7 @@ set(LibRoot "${CMAKE_CURRENT_SOURCE_DIR}/${LibraryVersion}")
 set(ArchivePath "${LibRoot}.tar.gz")
 if(NOT EXISTS ${ArchivePath})
   file(DOWNLOAD
-    "https://github.com/breez/breez-liquid-sdk/releases/download/${LibraryVersion}/other.tar.gz"
+    "https://github.com/breez/breez-liquid-sdk-flutter/releases/download/${TagName}/other.tar.gz"
     ${ArchivePath}
     TLS_VERIFY ON
   )

--- a/packages/flutter/linux/CMakeLists.txt
+++ b/packages/flutter/linux/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(TagName "0.1.0") # generated; do not edit
-set(LibraryVersion "breez_liquid-v${TagName}")
+set(TagName "v0.1.0") # generated; do not edit
+set(LibraryVersion "breez_liquid-${TagName}")
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/packages/flutter/macos/flutter_breez_liquid.podspec
+++ b/packages/flutter/macos/flutter_breez_liquid.podspec
@@ -1,10 +1,11 @@
-release_tag_name = 'breez_liquid-v0.1.0' # generated; do not edit
+tag_name = '0.1.0' # generated; do not edit
+release_tag_name = "breez_liquid-v#{tag_name}"
 
 # We cannot distribute the XCFramework alongside the library directly,
 # so we have to fetch the correct version here.
 framework_name = 'breez_liquid_sdk.xcframework'
 remote_zip_name = "#{framework_name}.zip"
-url = "https://github.com/breez/breez-liquid-sdk/releases/download/#{release_tag_name}/#{remote_zip_name}"
+url = "https://github.com/breez/breez-liquid-sdk-flutter/releases/download/#{tag_name}/#{remote_zip_name}.zip"
 local_zip_name = "#{release_tag_name}.zip"
 `
 cd Frameworks
@@ -21,7 +22,7 @@ cd -
 
 Pod::Spec.new do |spec|
   spec.name          = 'flutter_breez_liquid'
-  spec.version       = '0.1.0'
+  spec.version       = "#{tag_name}"
   spec.license       = { :file => '../LICENSE' }
   spec.homepage      = 'https://breez.technology'
   spec.authors       = { 'Breez' => 'contact@breez.technology' }

--- a/packages/flutter/macos/flutter_breez_liquid.podspec
+++ b/packages/flutter/macos/flutter_breez_liquid.podspec
@@ -1,4 +1,5 @@
-tag_name = 'v0.1.0' # generated; do not edit
+version = '0.1.0' # generated; do not edit
+tag_name = "v#{version}"
 release_tag_name = "breez_liquid-#{tag_name}"
 
 # We cannot distribute the XCFramework alongside the library directly,
@@ -10,7 +11,7 @@ local_zip_name = "#{release_tag_name}.zip"
 
 Pod::Spec.new do |spec|
   spec.name          = 'flutter_breez_liquid'
-  spec.version       = "#{tag_name}"
+  spec.version       = "#{version}"
   spec.license       = { :file => '../LICENSE' }
   spec.homepage      = 'https://breez.technology'
   spec.authors       = { 'Breez' => 'contact@breez.technology' }

--- a/packages/flutter/macos/flutter_breez_liquid.podspec
+++ b/packages/flutter/macos/flutter_breez_liquid.podspec
@@ -1,5 +1,5 @@
-tag_name = '0.1.0' # generated; do not edit
-release_tag_name = "breez_liquid-v#{tag_name}"
+tag_name = 'v0.1.0' # generated; do not edit
+release_tag_name = "breez_liquid-#{tag_name}"
 
 # We cannot distribute the XCFramework alongside the library directly,
 # so we have to fetch the correct version here.

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -2,6 +2,8 @@ name: flutter_breez_liquid
 description: Flutter wrapper around Dart bindings for the Breez Liquid SDK
 version: 0.1.0
 homepage: https://breez.technology
+repository: https://github.com/breez/breez-liquid-sdk-flutter
+publish_to: 'none'
 
 environment:
   sdk: '>=3.4.0 <4.0.0'
@@ -10,7 +12,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  breez_liquid: ^0.1.0
+  breez_liquid:
+    git:
+      url: https://github.com/breez/breez-liquid-sdk-dart
   ffigen: ">=8.0.0 <=11.0.0"
 
 dev_dependencies:

--- a/packages/flutter/windows/CMakeLists.txt
+++ b/packages/flutter/windows/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(TagName "0.1.0") # generated; do not edit
-set(LibraryVersion "breez_liquid-v${TagName}")
+set(TagName "v0.1.0") # generated; do not edit
+set(LibraryVersion "breez_liquid-${TagName}")
 
 # TODO Remove this workaround once Flutter supports Windows ARM.
 # https://github.com/flutter/flutter/issues/116196

--- a/packages/flutter/windows/CMakeLists.txt
+++ b/packages/flutter/windows/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(LibraryVersion "breez_liquid-v0.1.0") # generated; do not edit
+set(TagName "0.1.0") # generated; do not edit
+set(LibraryVersion "breez_liquid-v${TagName}")
 
 # TODO Remove this workaround once Flutter supports Windows ARM.
 # https://github.com/flutter/flutter/issues/116196
@@ -19,7 +20,7 @@ set(LibRoot "${CMAKE_CURRENT_SOURCE_DIR}/${LibraryVersion}")
 set(ArchivePath "${LibRoot}.tar.gz")
 if(NOT EXISTS ${ArchivePath})
   file(DOWNLOAD
-    "https://github.com/breez/breez-liquid-sdk/releases/download/${LibraryVersion}/other.tar.gz"
+    "https://github.com/breez/breez-liquid-sdk-flutter/releases/download/${TagName}/other.tar.gz"
     ${ArchivePath}
     TLS_VERIFY ON
   )


### PR DESCRIPTION
This PR adds the necessary steps to the publishing CI to publish Dart and Flutter.

**Dart**
- Update Dart package files
- Tag the Dart package

**Flutter**
- Build android, ios & other artifacts
- Update Flutter package files
- Override pubspec with Dart tag
- Tag the Flutter package
- Release the package with artifacts