### PR TITLE
Attempt to load Breez Liquid library via `ExternalLibrary.process()` if t fails to load via `open()`

### DIFF
--- a/packages/dart/lib/breez_liquid.dart
+++ b/packages/dart/lib/breez_liquid.dart
@@ -6,12 +6,23 @@ export 'src/model.dart';
 export 'src/error.dart';
 export 'src/bindings/duplicates.dart';
 
+import 'dart:io';
+
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'src/frb_generated.dart';
 
 typedef BreezLiquid = RustLibApi;
 typedef BreezLiquidImpl = RustLibApiImpl;
 
+const libName = 'breez_liquid_sdk';
+
 Future<void> initialize({ExternalLibrary? dylib}) {
+  if (dylib == null && (Platform.isIOS || Platform.isMacOS)) {
+    try {
+      dylib = ExternalLibrary.open("$libName.framework/$libName");
+    } catch (e) {
+      dylib = ExternalLibrary.process(iKnowHowToUseIt: true);
+    }
+  }
   return RustLib.init(externalLibrary: dylib);
 }


### PR DESCRIPTION
`ExternalLibrary.process()` resolves any symbol in a library currently loaded with global visibility.