### PR TITLE
Bug fixes & improvements on Flutter plugin example app

### DIFF
--- a/packages/flutter/example/ios/Podfile.lock
+++ b/packages/flutter/example/ios/Podfile.lock
@@ -1,27 +1,117 @@
 PODS:
   - Flutter (1.0.0)
   - flutter_breez_liquid (0.1.0)
+  - flutter_secure_storage (6.0.0):
+    - Flutter
+  - GoogleDataTransport (9.4.1):
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleMLKit/BarcodeScanning (6.0.0):
+    - GoogleMLKit/MLKitCore
+    - MLKitBarcodeScanning (~> 5.0.0)
+  - GoogleMLKit/MLKitCore (6.0.0):
+    - MLKitCommon (~> 11.0.0)
+  - GoogleToolboxForMac/Defines (4.2.1)
+  - GoogleToolboxForMac/Logger (4.2.1):
+    - GoogleToolboxForMac/Defines (= 4.2.1)
+  - "GoogleToolboxForMac/NSData+zlib (4.2.1)":
+    - GoogleToolboxForMac/Defines (= 4.2.1)
+  - GoogleUtilities/Environment (7.13.3):
+    - GoogleUtilities/Privacy
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Logger (7.13.3):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.3)
+  - GoogleUtilities/UserDefaults (7.13.3):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilitiesComponents (1.1.0):
+    - GoogleUtilities/Logger
+  - GTMSessionFetcher/Core (3.5.0)
+  - MLImage (1.0.0-beta5)
+  - MLKitBarcodeScanning (5.0.0):
+    - MLKitCommon (~> 11.0)
+    - MLKitVision (~> 7.0)
+  - MLKitCommon (11.0.0):
+    - GoogleDataTransport (< 10.0, >= 9.4.1)
+    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
+    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
+    - GoogleUtilities/UserDefaults (< 8.0, >= 7.13.0)
+    - GoogleUtilitiesComponents (~> 1.0)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
+  - MLKitVision (7.0.0):
+    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
+    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
+    - MLImage (= 1.0.0-beta5)
+    - MLKitCommon (~> 11.0)
+  - mobile_scanner (5.1.1):
+    - Flutter
+    - GoogleMLKit/BarcodeScanning (~> 6.0.0)
+  - nanopb (2.30910.0):
+    - nanopb/decode (= 2.30910.0)
+    - nanopb/encode (= 2.30910.0)
+  - nanopb/decode (2.30910.0)
+  - nanopb/encode (2.30910.0)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - PromisesObjC (2.4.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_breez_liquid (from `.symlinks/plugins/flutter_breez_liquid/ios`)
+  - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+
+SPEC REPOS:
+  trunk:
+    - GoogleDataTransport
+    - GoogleMLKit
+    - GoogleToolboxForMac
+    - GoogleUtilities
+    - GoogleUtilitiesComponents
+    - GTMSessionFetcher
+    - MLImage
+    - MLKitBarcodeScanning
+    - MLKitCommon
+    - MLKitVision
+    - nanopb
+    - PromisesObjC
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   flutter_breez_liquid:
     :path: ".symlinks/plugins/flutter_breez_liquid/ios"
+  flutter_secure_storage:
+    :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  mobile_scanner:
+    :path: ".symlinks/plugins/mobile_scanner/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_breez_liquid: 90494dd8df26d6258f0d2a90663204ee6257ede2
+  flutter_breez_liquid: fff5f2d9bc7c3b396a87ab41540a223e06de694b
+  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
+  GoogleMLKit: 97ac7af399057e99182ee8edfa8249e3226a4065
+  GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
+  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
+  GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  MLImage: 1824212150da33ef225fbd3dc49f184cf611046c
+  MLKitBarcodeScanning: 10ca0845a6d15f2f6e911f682a1998b68b973e8b
+  MLKitCommon: afec63980417d29ffbb4790529a1b0a2291699e1
+  MLKitVision: e858c5f125ecc288e4a31127928301eaba9ae0c1
+  mobile_scanner: 8564358885a9253c43f822435b70f9345c87224f
+  nanopb: 438bc412db1928dac798aa6fd75726007be04262
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 

--- a/packages/flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -47,7 +47,6 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C57C33264F3AA95B9DE5A13B /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		E884E5F32BD4518000044516 /* breez_liquid_sdk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = breez_liquid_sdk.h; path = ../../ios/Classes/breez_liquid_sdk.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,7 +83,6 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
-				E884E5F32BD4518000044516 /* breez_liquid_sdk.h */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
@@ -141,6 +139,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				C56A3EBC76148D6EE9073B37 /* [CP] Embed Pods Frameworks */,
+				ADFDF83671C1B34F4FA521FB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -251,6 +250,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		ADFDF83671C1B34F4FA521FB /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		C56A3EBC76148D6EE9073B37 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/flutter/example/ios/Runner/AppDelegate.swift
+++ b/packages/flutter/example/ios/Runner/AppDelegate.swift
@@ -7,8 +7,6 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    let dummy = dummy_method_to_enforce_bundling()
-    print(dummy)
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/packages/flutter/example/ios/Runner/Info.plist
+++ b/packages/flutter/example/ios/Runner/Info.plist
@@ -47,5 +47,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera permission is required for QR code scanning.</string>
 </dict>
 </plist>

--- a/packages/flutter/example/ios/Runner/Runner-Bridging-Header.h
+++ b/packages/flutter/example/ios/Runner/Runner-Bridging-Header.h
@@ -1,2 +1,1 @@
 #import "GeneratedPluginRegistrant.h"
-#import "breez_liquid_sdk.h"

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -15,7 +15,7 @@ void main() async {
   final credentialsManager = CredentialsManager(keyChain: KeyChain());
   final mnemonic = await credentialsManager.restoreMnemonic();
   if (mnemonic.isNotEmpty) {
-    reconnect(liquidSDK: liquidSDK, mnemonic: mnemonic);
+    await reconnect(liquidSDK: liquidSDK, mnemonic: mnemonic);
   }
   runApp(App(credentialsManager: credentialsManager, liquidSDK: liquidSDK));
 }

--- a/packages/flutter/example/lib/routes/home/widgets/balance.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/balance.dart
@@ -19,9 +19,6 @@ class Balance extends StatelessWidget {
           return const Center(child: Text('Loading...'));
         }
 
-        if (walletInfoSnapshot.requireData.balanceSat != BigInt.zero) {
-          return const Center(child: Text('No balance.'));
-        }
         final walletInfo = walletInfoSnapshot.data!;
 
         return Center(

--- a/packages/flutter/example/lib/routes/home/widgets/payment_list/payment_list.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/payment_list/payment_list.dart
@@ -30,7 +30,7 @@ class PaymentList extends StatelessWidget {
           );
         }
 
-        final paymentList = paymentsSnapshot.data!;
+        List<Payment> paymentList = paymentsSnapshot.data!.reversed.toList();
 
         return RefreshIndicator(
           onRefresh: () async {

--- a/packages/flutter/example/lib/routes/home/widgets/qr_scan/barcode_scanner_simple.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/qr_scan/barcode_scanner_simple.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_breez_liquid_example/routes/home/widgets/qr_scan/scan_overlay.dart';
+import 'package:flutter_breez_liquid_example/routes/home/widgets/qr_scan/scanner_button_widgets.dart';
 import 'package:flutter_breez_liquid_example/routes/home/widgets/qr_scan/scanner_error_widget.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
@@ -82,6 +83,7 @@ class _BarcodeScannerState extends State<BarcodeScanner> with WidgetsBindingObse
     var scanWindowDimension = MediaQuery.of(context).size.width - 72;
     return Scaffold(
       body: Stack(
+        fit: StackFit.expand,
         children: [
           MobileScanner(
             scanWindow: Rect.fromCenter(
@@ -97,6 +99,18 @@ class _BarcodeScannerState extends State<BarcodeScanner> with WidgetsBindingObse
               return const ScanOverlay();
             },
             fit: BoxFit.cover,
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 40),
+                  child: CancelScanButton(controller: controller),
+                )
+              ],
+            ),
           ),
         ],
       ),

--- a/packages/flutter/example/lib/routes/home/widgets/qr_scan/scanner_button_widgets.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/qr_scan/scanner_button_widgets.dart
@@ -128,3 +128,40 @@ class ToggleFlashlightButton extends StatelessWidget {
     );
   }
 }
+
+class CancelScanButton extends StatelessWidget {
+  const CancelScanButton({required this.controller, super.key});
+
+  final MobileScannerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: const BorderRadius.all(
+          Radius.circular(12.0),
+        ),
+        border: Border.all(
+          color: Colors.white.withOpacity(0.8),
+        ),
+      ),
+      child: TextButton(
+        style: TextButton.styleFrom(
+          padding: const EdgeInsets.only(
+            right: 35,
+            left: 35,
+          ),
+        ),
+        onPressed: () async {
+          controller.stop().then((_) => Navigator.of(context).pop());
+        },
+        child: const Text(
+          "CANCEL",
+          style: TextStyle(
+            color: Colors.white,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter/example/lib/routes/home/widgets/receive_payment/receive_payment_dialog.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/receive_payment/receive_payment_dialog.dart
@@ -60,10 +60,14 @@ class _ReceivePaymentDialogState extends State<ReceivePaymentDialog> {
                 if (invoice != null) ...[
                   AspectRatio(
                     aspectRatio: 1,
-                    child: QrImageView(
-                      embeddedImage: const AssetImage("assets/icons/app_icon.png"),
-                      data: invoice!.toUpperCase(),
-                      size: 200.0,
+                    child: SizedBox(
+                      width: 200.0,
+                      height: 200.0,
+                      child: QrImageView(
+                        embeddedImage: const AssetImage("assets/icons/app_icon.png"),
+                        data: invoice!.toUpperCase(),
+                        size: 200.0,
+                      ),
                     ),
                   ),
                   if (payerAmountSat != null && feesSat != null) ...[


### PR DESCRIPTION
This PR adds various bug fixes & improvements on Flutter plugin example app.

#### Changelist:
- **Bugfix**: Wait `reconnect` attempt on startup
  - Not waiting forced you to recover on each attempt even if your credentials were saved on device
- **Bugfix**: Bound the size of QR image view
- Reverse the payment list
  - Should be reverted once this issue is addressed: 
  #358 
- Do not show "No Balance" text when balance is 0
- Add required permissions for QR scan on iOS
- Add a cancel button to mobile scanner
  - It was not possible to cancel scanning unless a valid QR was read on iOS
- Remove unneeded resource files from iOS Project
  - Remove `breez_liquid_sdk.h`
  - Remove outdated method to enforce bundling on AppDelegate
- Install pods