### PR TITLE
Remove duplicate `refund_send`, `refund_send_non_cooperative`

### DIFF
--- a/lib/core/src/send_swap.rs
+++ b/lib/core/src/send_swap.rs
@@ -383,7 +383,7 @@ impl SendSwapStateHandler {
         Ok(())
     }
 
-    async fn refund(&self, swap: &SendSwap) -> Result<String, PaymentError> {
+    pub(crate) async fn refund(&self, swap: &SendSwap) -> Result<String, PaymentError> {
         let output_address = self.onchain_wallet.next_unused_address().await?.to_string();
 
         let cooperative_refund_tx_fees_sat =


### PR DESCRIPTION
Remove `refund_send`, `refund_send_non_cooperative` from `sdk.rs`, which are also available in `swapper` module.