### PR TITLE
Fix transition from `RefundPending` to `Failed`

### DIFF
--- a/lib/core/src/persist/chain.rs
+++ b/lib/core/src/persist/chain.rs
@@ -198,7 +198,10 @@ impl Persister {
 
     pub(crate) fn list_pending_chain_swaps(&self) -> Result<Vec<ChainSwap>> {
         let con: Connection = self.get_connection()?;
-        self.list_chain_swaps_by_state(&con, vec![PaymentState::Pending])
+        self.list_chain_swaps_by_state(
+            &con,
+            vec![PaymentState::Pending, PaymentState::RefundPending],
+        )
     }
 
     pub(crate) fn list_refundable_chain_swaps(&self) -> Result<Vec<ChainSwap>> {


### PR DESCRIPTION
This PR includes `RefundPending` state in the list_pending filter. This is done for swaps that can be refunded, like Chain Swaps and Send Swaps.

Without this, refunded payments never transition away from `RefundPending` to `Failed` (refunded), because they're not considered a pending swap when handling the final transition.