### PR TITLE
Pin `flutter_rust_bridge` to 2.0.0

### DIFF
--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -24,6 +24,6 @@ dev_dependencies:
   test: ^1.25.5
 dependencies:
   ffi: ^2.1.2
-  flutter_rust_bridge: ^2.0.0
+  flutter_rust_bridge: 2.0.0
   freezed_annotation: ^2.4.1
   meta: ^1.12.0 # meta is pinned to version 1.12.0 by integration_test from the flutter SDK.

--- a/packages/flutter/example/pubspec.yaml
+++ b/packages/flutter/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  flutter_rust_bridge: ^2.0.0
+  flutter_rust_bridge: 2.0.0
   flutter_breez_liquid:
     git:
       url: https://github.com/breez/breez-liquid-sdk-flutter


### PR DESCRIPTION
This PR addresses CI failures on "Check Dart/Flutter bindings" step.

Reason for pinning to 2.0.0 instead of upgrading to 2.1.0:
* 2.1.0 has introduced a regression: https://github.com/fzyzcjy/flutter_rust_bridge/pull/2150#issuecomment-2213773291
   - Respective issue: https://github.com/fzyzcjy/flutter_rust_bridge/issues/2194