### PR TITLE
Remove unused Config zero_conf_min_fee_rate param

### DIFF
--- a/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
+++ b/lib/bindings/langs/flutter/breez_liquid_sdk/include/breez_liquid_sdk.h
@@ -19,13 +19,6 @@ typedef struct _Dart_Handle* Dart_Handle;
 #define LOWBALL_FEE_RATE_SAT_PER_VBYTE 0.01
 
 /**
- * The minimum acceptable fee rate when claiming using zero-conf
- */
-#define DEFAULT_ZERO_CONF_MIN_FEE_RATE_TESTNET 0.1
-
-#define DEFAULT_ZERO_CONF_MIN_FEE_RATE_MAINNET 0.01
-
-/**
  * The maximum acceptable amount in satoshi when claiming using zero-conf
  */
 #define DEFAULT_ZERO_CONF_MAX_SAT 100000
@@ -203,7 +196,6 @@ typedef struct wire_cst_config {
   struct wire_cst_list_prim_u_8_strict *working_dir;
   int32_t network;
   uint64_t payment_timeout_sec;
-  float zero_conf_min_fee_rate;
   uint64_t *zero_conf_max_amount_sat;
 } wire_cst_config;
 

--- a/lib/bindings/langs/flutter/pubspec.lock
+++ b/lib/bindings/langs/flutter/pubspec.lock
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:

--- a/lib/bindings/src/breez_liquid_sdk.udl
+++ b/lib/bindings/src/breez_liquid_sdk.udl
@@ -288,7 +288,6 @@ dictionary Config {
     string working_dir;
     LiquidNetwork network;
     u64 payment_timeout_sec;
-    f32 zero_conf_min_fee_rate;
     u64? zero_conf_max_amount_sat;
 };
 

--- a/lib/core/src/frb_generated.io.rs
+++ b/lib/core/src/frb_generated.io.rs
@@ -416,7 +416,6 @@ impl CstDecode<crate::model::Config> for wire_cst_config {
             working_dir: self.working_dir.cst_decode(),
             network: self.network.cst_decode(),
             payment_timeout_sec: self.payment_timeout_sec.cst_decode(),
-            zero_conf_min_fee_rate: self.zero_conf_min_fee_rate.cst_decode(),
             zero_conf_max_amount_sat: self.zero_conf_max_amount_sat.cst_decode(),
         }
     }
@@ -1471,7 +1470,6 @@ impl NewWithNullPtr for wire_cst_config {
             working_dir: core::ptr::null_mut(),
             network: Default::default(),
             payment_timeout_sec: Default::default(),
-            zero_conf_min_fee_rate: Default::default(),
             zero_conf_max_amount_sat: core::ptr::null_mut(),
         }
     }
@@ -2992,7 +2990,6 @@ pub struct wire_cst_config {
     working_dir: *mut wire_cst_list_prim_u_8_strict,
     network: i32,
     payment_timeout_sec: u64,
-    zero_conf_min_fee_rate: f32,
     zero_conf_max_amount_sat: *mut u64,
 }
 #[repr(C)]

--- a/lib/core/src/frb_generated.rs
+++ b/lib/core/src/frb_generated.rs
@@ -1622,12 +1622,6 @@ impl CstDecode<bool> for bool {
         self
     }
 }
-impl CstDecode<f32> for f32 {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    fn cst_decode(self) -> f32 {
-        self
-    }
-}
 impl CstDecode<f64> for f64 {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> f64 {
@@ -1862,7 +1856,6 @@ impl SseDecode for crate::model::Config {
         let mut var_workingDir = <String>::sse_decode(deserializer);
         let mut var_network = <crate::model::LiquidNetwork>::sse_decode(deserializer);
         let mut var_paymentTimeoutSec = <u64>::sse_decode(deserializer);
-        let mut var_zeroConfMinFeeRate = <f32>::sse_decode(deserializer);
         let mut var_zeroConfMaxAmountSat = <Option<u64>>::sse_decode(deserializer);
         return crate::model::Config {
             liquid_electrum_url: var_liquidElectrumUrl,
@@ -1870,7 +1863,6 @@ impl SseDecode for crate::model::Config {
             working_dir: var_workingDir,
             network: var_network,
             payment_timeout_sec: var_paymentTimeoutSec,
-            zero_conf_min_fee_rate: var_zeroConfMinFeeRate,
             zero_conf_max_amount_sat: var_zeroConfMaxAmountSat,
         };
     }
@@ -1908,13 +1900,6 @@ impl SseDecode for crate::bindings::CurrencyInfo {
             localized_name: var_localizedName,
             locale_overrides: var_localeOverrides,
         };
-    }
-}
-
-impl SseDecode for f32 {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        deserializer.cursor.read_f32::<NativeEndian>().unwrap()
     }
 }
 
@@ -3395,7 +3380,6 @@ impl flutter_rust_bridge::IntoDart for crate::model::Config {
             self.working_dir.into_into_dart().into_dart(),
             self.network.into_into_dart().into_dart(),
             self.payment_timeout_sec.into_into_dart().into_dart(),
-            self.zero_conf_min_fee_rate.into_into_dart().into_dart(),
             self.zero_conf_max_amount_sat.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -4926,7 +4910,6 @@ impl SseEncode for crate::model::Config {
         <String>::sse_encode(self.working_dir, serializer);
         <crate::model::LiquidNetwork>::sse_encode(self.network, serializer);
         <u64>::sse_encode(self.payment_timeout_sec, serializer);
-        <f32>::sse_encode(self.zero_conf_min_fee_rate, serializer);
         <Option<u64>>::sse_encode(self.zero_conf_max_amount_sat, serializer);
     }
 }
@@ -4949,13 +4932,6 @@ impl SseEncode for crate::bindings::CurrencyInfo {
         <Option<crate::bindings::Symbol>>::sse_encode(self.uniq_symbol, serializer);
         <Vec<crate::bindings::LocalizedName>>::sse_encode(self.localized_name, serializer);
         <Vec<crate::bindings::LocaleOverrides>>::sse_encode(self.locale_overrides, serializer);
-    }
-}
-
-impl SseEncode for f32 {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        serializer.cursor.write_f32::<NativeEndian>(self).unwrap();
     }
 }
 

--- a/lib/core/src/model.rs
+++ b/lib/core/src/model.rs
@@ -11,10 +11,7 @@ use sdk_common::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{LiquidSdkResult, PaymentError};
-use crate::receive_swap::{
-    DEFAULT_ZERO_CONF_MAX_SAT, DEFAULT_ZERO_CONF_MIN_FEE_RATE_MAINNET,
-    DEFAULT_ZERO_CONF_MIN_FEE_RATE_TESTNET,
-};
+use crate::receive_swap::DEFAULT_ZERO_CONF_MAX_SAT;
 use crate::utils;
 
 pub const STANDARD_FEE_RATE_SAT_PER_VBYTE: f32 = 0.1;
@@ -32,8 +29,6 @@ pub struct Config {
     pub network: LiquidNetwork,
     /// Send payment timeout. See [crate::sdk::LiquidSdk::send_payment]
     pub payment_timeout_sec: u64,
-    /// Zero-conf minimum accepted fee-rate in sat/vbyte
-    pub zero_conf_min_fee_rate: f32,
     /// Maximum amount in satoshi to accept zero-conf payments with
     /// Defaults to [crate::receive_swap::DEFAULT_ZERO_CONF_MAX_SAT]
     pub zero_conf_max_amount_sat: Option<u64>,
@@ -47,7 +42,6 @@ impl Config {
             working_dir: ".".to_string(),
             network: LiquidNetwork::Mainnet,
             payment_timeout_sec: 15,
-            zero_conf_min_fee_rate: DEFAULT_ZERO_CONF_MIN_FEE_RATE_MAINNET,
             zero_conf_max_amount_sat: None,
         }
     }
@@ -59,7 +53,6 @@ impl Config {
             working_dir: ".".to_string(),
             network: LiquidNetwork::Testnet,
             payment_timeout_sec: 15,
-            zero_conf_min_fee_rate: DEFAULT_ZERO_CONF_MIN_FEE_RATE_TESTNET,
             zero_conf_max_amount_sat: None,
         }
     }

--- a/lib/core/src/receive_swap.rs
+++ b/lib/core/src/receive_swap.rs
@@ -17,9 +17,6 @@ use crate::{
     wallet::OnchainWallet,
 };
 
-/// The minimum acceptable fee rate when claiming using zero-conf
-pub const DEFAULT_ZERO_CONF_MIN_FEE_RATE_TESTNET: f32 = 0.1;
-pub const DEFAULT_ZERO_CONF_MIN_FEE_RATE_MAINNET: f32 = 0.01;
 /// The maximum acceptable amount in satoshi when claiming using zero-conf
 pub const DEFAULT_ZERO_CONF_MAX_SAT: u64 = 100_000;
 

--- a/packages/dart/lib/src/frb_generated.dart
+++ b/packages/dart/lib/src/frb_generated.dart
@@ -1324,15 +1324,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Config dco_decode_config(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 7) throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 6) throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
     return Config(
       liquidElectrumUrl: dco_decode_String(arr[0]),
       bitcoinElectrumUrl: dco_decode_String(arr[1]),
       workingDir: dco_decode_String(arr[2]),
       network: dco_decode_liquid_network(arr[3]),
       paymentTimeoutSec: dco_decode_u_64(arr[4]),
-      zeroConfMinFeeRate: dco_decode_f_32(arr[5]),
-      zeroConfMaxAmountSat: dco_decode_opt_box_autoadd_u_64(arr[6]),
+      zeroConfMaxAmountSat: dco_decode_opt_box_autoadd_u_64(arr[5]),
     );
   }
 
@@ -1361,12 +1360,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       localizedName: dco_decode_list_localized_name(arr[5]),
       localeOverrides: dco_decode_list_locale_overrides(arr[6]),
     );
-  }
-
-  @protected
-  double dco_decode_f_32(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return raw as double;
   }
 
   @protected
@@ -2727,7 +2720,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_workingDir = sse_decode_String(deserializer);
     var var_network = sse_decode_liquid_network(deserializer);
     var var_paymentTimeoutSec = sse_decode_u_64(deserializer);
-    var var_zeroConfMinFeeRate = sse_decode_f_32(deserializer);
     var var_zeroConfMaxAmountSat = sse_decode_opt_box_autoadd_u_64(deserializer);
     return Config(
         liquidElectrumUrl: var_liquidElectrumUrl,
@@ -2735,7 +2727,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         workingDir: var_workingDir,
         network: var_network,
         paymentTimeoutSec: var_paymentTimeoutSec,
-        zeroConfMinFeeRate: var_zeroConfMinFeeRate,
         zeroConfMaxAmountSat: var_zeroConfMaxAmountSat);
   }
 
@@ -2765,12 +2756,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         uniqSymbol: var_uniqSymbol,
         localizedName: var_localizedName,
         localeOverrides: var_localeOverrides);
-  }
-
-  @protected
-  double sse_decode_f_32(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    return deserializer.buffer.getFloat32();
   }
 
   @protected
@@ -3794,12 +3779,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  double cst_encode_f_32(double raw) {
-    // Codec=Cst (C-struct based), see doc to use other codecs
-    return raw;
-  }
-
-  @protected
   double cst_encode_f_64(double raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw;
@@ -4202,7 +4181,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.workingDir, serializer);
     sse_encode_liquid_network(self.network, serializer);
     sse_encode_u_64(self.paymentTimeoutSec, serializer);
-    sse_encode_f_32(self.zeroConfMinFeeRate, serializer);
     sse_encode_opt_box_autoadd_u_64(self.zeroConfMaxAmountSat, serializer);
   }
 
@@ -4223,12 +4201,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_symbol(self.uniqSymbol, serializer);
     sse_encode_list_localized_name(self.localizedName, serializer);
     sse_encode_list_locale_overrides(self.localeOverrides, serializer);
-  }
-
-  @protected
-  void sse_encode_f_32(double self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    serializer.buffer.putFloat32(self);
   }
 
   @protected

--- a/packages/dart/lib/src/frb_generated.io.dart
+++ b/packages/dart/lib/src/frb_generated.io.dart
@@ -186,9 +186,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   CurrencyInfo dco_decode_currency_info(dynamic raw);
 
   @protected
-  double dco_decode_f_32(dynamic raw);
-
-  @protected
   double dco_decode_f_64(dynamic raw);
 
   @protected
@@ -595,9 +592,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   CurrencyInfo sse_decode_currency_info(SseDeserializer deserializer);
-
-  @protected
-  double sse_decode_f_32(SseDeserializer deserializer);
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
@@ -1566,7 +1560,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.working_dir = cst_encode_String(apiObj.workingDir);
     wireObj.network = cst_encode_liquid_network(apiObj.network);
     wireObj.payment_timeout_sec = cst_encode_u_64(apiObj.paymentTimeoutSec);
-    wireObj.zero_conf_min_fee_rate = cst_encode_f_32(apiObj.zeroConfMinFeeRate);
     wireObj.zero_conf_max_amount_sat = cst_encode_opt_box_autoadd_u_64(apiObj.zeroConfMaxAmountSat);
   }
 
@@ -2356,9 +2349,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   bool cst_encode_bool(bool raw);
 
   @protected
-  double cst_encode_f_32(double raw);
-
-  @protected
   double cst_encode_f_64(double raw);
 
   @protected
@@ -2556,9 +2546,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_currency_info(CurrencyInfo self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_f_32(double self, SseSerializer serializer);
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);
@@ -4242,9 +4229,6 @@ final class wire_cst_config extends ffi.Struct {
   @ffi.Uint64()
   external int payment_timeout_sec;
 
-  @ffi.Float()
-  external double zero_conf_min_fee_rate;
-
   external ffi.Pointer<ffi.Uint64> zero_conf_max_amount_sat;
 }
 
@@ -4947,10 +4931,6 @@ final class wire_cst_send_payment_response extends ffi.Struct {
 const double STANDARD_FEE_RATE_SAT_PER_VBYTE = 0.1;
 
 const double LOWBALL_FEE_RATE_SAT_PER_VBYTE = 0.01;
-
-const double DEFAULT_ZERO_CONF_MIN_FEE_RATE_TESTNET = 0.1;
-
-const double DEFAULT_ZERO_CONF_MIN_FEE_RATE_MAINNET = 0.01;
 
 const int DEFAULT_ZERO_CONF_MAX_SAT = 100000;
 

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -43,9 +43,6 @@ class Config {
   /// Send payment timeout. See [crate::sdk::LiquidSdk::send_payment]
   final BigInt paymentTimeoutSec;
 
-  /// Zero-conf minimum accepted fee-rate in sat/vbyte
-  final double zeroConfMinFeeRate;
-
   /// Maximum amount in satoshi to accept zero-conf payments with
   /// Defaults to [crate::receive_swap::DEFAULT_ZERO_CONF_MAX_SAT]
   final BigInt? zeroConfMaxAmountSat;
@@ -56,7 +53,6 @@ class Config {
     required this.workingDir,
     required this.network,
     required this.paymentTimeoutSec,
-    required this.zeroConfMinFeeRate,
     this.zeroConfMaxAmountSat,
   });
 
@@ -67,7 +63,6 @@ class Config {
       workingDir.hashCode ^
       network.hashCode ^
       paymentTimeoutSec.hashCode ^
-      zeroConfMinFeeRate.hashCode ^
       zeroConfMaxAmountSat.hashCode;
 
   @override
@@ -80,7 +75,6 @@ class Config {
           workingDir == other.workingDir &&
           network == other.network &&
           paymentTimeoutSec == other.paymentTimeoutSec &&
-          zeroConfMinFeeRate == other.zeroConfMinFeeRate &&
           zeroConfMaxAmountSat == other.zeroConfMaxAmountSat;
 }
 

--- a/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
+++ b/packages/flutter/lib/flutter_breez_liquid_bindings_generated.dart
@@ -1510,9 +1510,6 @@ final class wire_cst_config extends ffi.Struct {
   @ffi.Uint64()
   external int payment_timeout_sec;
 
-  @ffi.Float()
-  external double zero_conf_min_fee_rate;
-
   external ffi.Pointer<ffi.Uint64> zero_conf_max_amount_sat;
 }
 
@@ -2218,10 +2215,6 @@ typedef WireSyncRust2DartDco = ffi.Pointer<DartCObject>;
 const double STANDARD_FEE_RATE_SAT_PER_VBYTE = 0.1;
 
 const double LOWBALL_FEE_RATE_SAT_PER_VBYTE = 0.01;
-
-const double DEFAULT_ZERO_CONF_MIN_FEE_RATE_TESTNET = 0.1;
-
-const double DEFAULT_ZERO_CONF_MIN_FEE_RATE_MAINNET = 0.01;
 
 const int DEFAULT_ZERO_CONF_MAX_SAT = 100000;
 

--- a/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKMapper.kt
+++ b/packages/react-native/android/src/main/java/com/breezliquidsdk/BreezLiquidSDKMapper.kt
@@ -123,7 +123,6 @@ fun asConfig(config: ReadableMap): Config? {
                 "workingDir",
                 "network",
                 "paymentTimeoutSec",
-                "zeroConfMinFeeRate",
             ),
         )
     ) {
@@ -134,7 +133,6 @@ fun asConfig(config: ReadableMap): Config? {
     val workingDir = config.getString("workingDir")!!
     val network = config.getString("network")?.let { asLiquidNetwork(it) }!!
     val paymentTimeoutSec = config.getDouble("paymentTimeoutSec").toULong()
-    val zeroConfMinFeeRate = config.getDouble("zeroConfMinFeeRate").toFloat()
     val zeroConfMaxAmountSat =
         if (hasNonNullKey(
                 config,
@@ -151,7 +149,6 @@ fun asConfig(config: ReadableMap): Config? {
         workingDir,
         network,
         paymentTimeoutSec,
-        zeroConfMinFeeRate,
         zeroConfMaxAmountSat,
     )
 }
@@ -163,7 +160,6 @@ fun readableMapOf(config: Config): ReadableMap =
         "workingDir" to config.workingDir,
         "network" to config.network.name.lowercase(),
         "paymentTimeoutSec" to config.paymentTimeoutSec,
-        "zeroConfMinFeeRate" to config.zeroConfMinFeeRate,
         "zeroConfMaxAmountSat" to config.zeroConfMaxAmountSat,
     )
 

--- a/packages/react-native/ios/BreezLiquidSDKMapper.swift
+++ b/packages/react-native/ios/BreezLiquidSDKMapper.swift
@@ -161,9 +161,6 @@ enum BreezLiquidSDKMapper {
         guard let paymentTimeoutSec = config["paymentTimeoutSec"] as? UInt64 else {
             throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentTimeoutSec", typeName: "Config"))
         }
-        guard let zeroConfMinFeeRate = config["zeroConfMinFeeRate"] as? Float else {
-            throw LiquidSdkError.Generic(message: errMissingMandatoryField(fieldName: "zeroConfMinFeeRate", typeName: "Config"))
-        }
         var zeroConfMaxAmountSat: UInt64?
         if hasNonNilKey(data: config, key: "zeroConfMaxAmountSat") {
             guard let zeroConfMaxAmountSatTmp = config["zeroConfMaxAmountSat"] as? UInt64 else {
@@ -178,7 +175,6 @@ enum BreezLiquidSDKMapper {
             workingDir: workingDir,
             network: network,
             paymentTimeoutSec: paymentTimeoutSec,
-            zeroConfMinFeeRate: zeroConfMinFeeRate,
             zeroConfMaxAmountSat: zeroConfMaxAmountSat
         )
     }
@@ -190,7 +186,6 @@ enum BreezLiquidSDKMapper {
             "workingDir": config.workingDir,
             "network": valueOf(liquidNetwork: config.network),
             "paymentTimeoutSec": config.paymentTimeoutSec,
-            "zeroConfMinFeeRate": config.zeroConfMinFeeRate,
             "zeroConfMaxAmountSat": config.zeroConfMaxAmountSat == nil ? nil : config.zeroConfMaxAmountSat,
         ]
     }

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -42,7 +42,6 @@ export interface Config {
     workingDir: string
     network: LiquidNetwork
     paymentTimeoutSec: number
-    zeroConfMinFeeRate: number
     zeroConfMaxAmountSat?: number
 }
 


### PR DESCRIPTION
It turns out the `zero_conf_min_fee_rate` Config param is no longer used, so remove it

Fixes #371 