### PR TITLE
Rename `wallet` to `instance`

### DIFF
--- a/packages/dart/lib/src/bindings.freezed.dart
+++ b/packages/dart/lib/src/bindings.freezed.dart
@@ -33,6 +33,9 @@ class _$AesSuccessActionDataResultCopyWithImpl<$Res, $Val extends AesSuccessActi
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of AesSuccessActionDataResult
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -53,6 +56,8 @@ class __$$AesSuccessActionDataResult_DecryptedImplCopyWithImpl<$Res>
       $Res Function(_$AesSuccessActionDataResult_DecryptedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AesSuccessActionDataResult
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -91,7 +96,9 @@ class _$AesSuccessActionDataResult_DecryptedImpl extends AesSuccessActionDataRes
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AesSuccessActionDataResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AesSuccessActionDataResult_DecryptedImplCopyWith<_$AesSuccessActionDataResult_DecryptedImpl>
@@ -105,7 +112,10 @@ abstract class AesSuccessActionDataResult_Decrypted extends AesSuccessActionData
   const AesSuccessActionDataResult_Decrypted._() : super._();
 
   AesSuccessActionDataDecrypted get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AesSuccessActionDataResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AesSuccessActionDataResult_DecryptedImplCopyWith<_$AesSuccessActionDataResult_DecryptedImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -129,6 +139,8 @@ class __$$AesSuccessActionDataResult_ErrorStatusImplCopyWithImpl<$Res>
       $Res Function(_$AesSuccessActionDataResult_ErrorStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of AesSuccessActionDataResult
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -167,7 +179,9 @@ class _$AesSuccessActionDataResult_ErrorStatusImpl extends AesSuccessActionDataR
   @override
   int get hashCode => Object.hash(runtimeType, reason);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of AesSuccessActionDataResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$AesSuccessActionDataResult_ErrorStatusImplCopyWith<_$AesSuccessActionDataResult_ErrorStatusImpl>
@@ -181,7 +195,10 @@ abstract class AesSuccessActionDataResult_ErrorStatus extends AesSuccessActionDa
   const AesSuccessActionDataResult_ErrorStatus._() : super._();
 
   String get reason;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of AesSuccessActionDataResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$AesSuccessActionDataResult_ErrorStatusImplCopyWith<_$AesSuccessActionDataResult_ErrorStatusImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -203,6 +220,9 @@ class _$InputTypeCopyWithImpl<$Res, $Val extends InputType> implements $InputTyp
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -222,6 +242,8 @@ class __$$InputType_BitcoinAddressImplCopyWithImpl<$Res>
       _$InputType_BitcoinAddressImpl _value, $Res Function(_$InputType_BitcoinAddressImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -260,7 +282,9 @@ class _$InputType_BitcoinAddressImpl extends InputType_BitcoinAddress {
   @override
   int get hashCode => Object.hash(runtimeType, address);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InputType_BitcoinAddressImplCopyWith<_$InputType_BitcoinAddressImpl> get copyWith =>
@@ -273,7 +297,10 @@ abstract class InputType_BitcoinAddress extends InputType {
   const InputType_BitcoinAddress._() : super._();
 
   BitcoinAddressData get address;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InputType_BitcoinAddressImplCopyWith<_$InputType_BitcoinAddressImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -294,6 +321,8 @@ class __$$InputType_Bolt11ImplCopyWithImpl<$Res> extends _$InputTypeCopyWithImpl
       _$InputType_Bolt11Impl _value, $Res Function(_$InputType_Bolt11Impl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -332,7 +361,9 @@ class _$InputType_Bolt11Impl extends InputType_Bolt11 {
   @override
   int get hashCode => Object.hash(runtimeType, invoice);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InputType_Bolt11ImplCopyWith<_$InputType_Bolt11Impl> get copyWith =>
@@ -344,7 +375,10 @@ abstract class InputType_Bolt11 extends InputType {
   const InputType_Bolt11._() : super._();
 
   LNInvoice get invoice;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InputType_Bolt11ImplCopyWith<_$InputType_Bolt11Impl> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -364,6 +398,8 @@ class __$$InputType_NodeIdImplCopyWithImpl<$Res> extends _$InputTypeCopyWithImpl
       _$InputType_NodeIdImpl _value, $Res Function(_$InputType_NodeIdImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -402,7 +438,9 @@ class _$InputType_NodeIdImpl extends InputType_NodeId {
   @override
   int get hashCode => Object.hash(runtimeType, nodeId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InputType_NodeIdImplCopyWith<_$InputType_NodeIdImpl> get copyWith =>
@@ -414,7 +452,10 @@ abstract class InputType_NodeId extends InputType {
   const InputType_NodeId._() : super._();
 
   String get nodeId;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InputType_NodeIdImplCopyWith<_$InputType_NodeIdImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -432,6 +473,8 @@ class __$$InputType_UrlImplCopyWithImpl<$Res> extends _$InputTypeCopyWithImpl<$R
   __$$InputType_UrlImplCopyWithImpl(_$InputType_UrlImpl _value, $Res Function(_$InputType_UrlImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -470,7 +513,9 @@ class _$InputType_UrlImpl extends InputType_Url {
   @override
   int get hashCode => Object.hash(runtimeType, url);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InputType_UrlImplCopyWith<_$InputType_UrlImpl> get copyWith =>
@@ -482,7 +527,10 @@ abstract class InputType_Url extends InputType {
   const InputType_Url._() : super._();
 
   String get url;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InputType_UrlImplCopyWith<_$InputType_UrlImpl> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -503,6 +551,8 @@ class __$$InputType_LnUrlPayImplCopyWithImpl<$Res>
       _$InputType_LnUrlPayImpl _value, $Res Function(_$InputType_LnUrlPayImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -541,7 +591,9 @@ class _$InputType_LnUrlPayImpl extends InputType_LnUrlPay {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InputType_LnUrlPayImplCopyWith<_$InputType_LnUrlPayImpl> get copyWith =>
@@ -553,7 +605,10 @@ abstract class InputType_LnUrlPay extends InputType {
   const InputType_LnUrlPay._() : super._();
 
   LnUrlPayRequestData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InputType_LnUrlPayImplCopyWith<_$InputType_LnUrlPayImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -575,6 +630,8 @@ class __$$InputType_LnUrlWithdrawImplCopyWithImpl<$Res>
       _$InputType_LnUrlWithdrawImpl _value, $Res Function(_$InputType_LnUrlWithdrawImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -613,7 +670,9 @@ class _$InputType_LnUrlWithdrawImpl extends InputType_LnUrlWithdraw {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InputType_LnUrlWithdrawImplCopyWith<_$InputType_LnUrlWithdrawImpl> get copyWith =>
@@ -626,7 +685,10 @@ abstract class InputType_LnUrlWithdraw extends InputType {
   const InputType_LnUrlWithdraw._() : super._();
 
   LnUrlWithdrawRequestData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InputType_LnUrlWithdrawImplCopyWith<_$InputType_LnUrlWithdrawImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -648,6 +710,8 @@ class __$$InputType_LnUrlAuthImplCopyWithImpl<$Res>
       _$InputType_LnUrlAuthImpl _value, $Res Function(_$InputType_LnUrlAuthImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -686,7 +750,9 @@ class _$InputType_LnUrlAuthImpl extends InputType_LnUrlAuth {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InputType_LnUrlAuthImplCopyWith<_$InputType_LnUrlAuthImpl> get copyWith =>
@@ -698,7 +764,10 @@ abstract class InputType_LnUrlAuth extends InputType {
   const InputType_LnUrlAuth._() : super._();
 
   LnUrlAuthRequestData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InputType_LnUrlAuthImplCopyWith<_$InputType_LnUrlAuthImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -720,6 +789,8 @@ class __$$InputType_LnUrlErrorImplCopyWithImpl<$Res>
       _$InputType_LnUrlErrorImpl _value, $Res Function(_$InputType_LnUrlErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -758,7 +829,9 @@ class _$InputType_LnUrlErrorImpl extends InputType_LnUrlError {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$InputType_LnUrlErrorImplCopyWith<_$InputType_LnUrlErrorImpl> get copyWith =>
@@ -770,7 +843,10 @@ abstract class InputType_LnUrlError extends InputType {
   const InputType_LnUrlError._() : super._();
 
   LnUrlErrorData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of InputType
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$InputType_LnUrlErrorImplCopyWith<_$InputType_LnUrlErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -794,6 +870,9 @@ class _$SuccessActionProcessedCopyWithImpl<$Res, $Val extends SuccessActionProce
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -815,6 +894,8 @@ class __$$SuccessActionProcessed_AesImplCopyWithImpl<$Res>
       _$SuccessActionProcessed_AesImpl _value, $Res Function(_$SuccessActionProcessed_AesImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -828,6 +909,8 @@ class __$$SuccessActionProcessed_AesImplCopyWithImpl<$Res>
     ));
   }
 
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
   $AesSuccessActionDataResultCopyWith<$Res> get result {
@@ -861,7 +944,9 @@ class _$SuccessActionProcessed_AesImpl extends SuccessActionProcessed_Aes {
   @override
   int get hashCode => Object.hash(runtimeType, result);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SuccessActionProcessed_AesImplCopyWith<_$SuccessActionProcessed_AesImpl> get copyWith =>
@@ -874,7 +959,10 @@ abstract class SuccessActionProcessed_Aes extends SuccessActionProcessed {
   const SuccessActionProcessed_Aes._() : super._();
 
   AesSuccessActionDataResult get result;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SuccessActionProcessed_AesImplCopyWith<_$SuccessActionProcessed_AesImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -896,6 +984,8 @@ class __$$SuccessActionProcessed_MessageImplCopyWithImpl<$Res>
       _$SuccessActionProcessed_MessageImpl _value, $Res Function(_$SuccessActionProcessed_MessageImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -934,7 +1024,9 @@ class _$SuccessActionProcessed_MessageImpl extends SuccessActionProcessed_Messag
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SuccessActionProcessed_MessageImplCopyWith<_$SuccessActionProcessed_MessageImpl> get copyWith =>
@@ -948,7 +1040,10 @@ abstract class SuccessActionProcessed_Message extends SuccessActionProcessed {
   const SuccessActionProcessed_Message._() : super._();
 
   MessageSuccessActionData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SuccessActionProcessed_MessageImplCopyWith<_$SuccessActionProcessed_MessageImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -970,6 +1065,8 @@ class __$$SuccessActionProcessed_UrlImplCopyWithImpl<$Res>
       _$SuccessActionProcessed_UrlImpl _value, $Res Function(_$SuccessActionProcessed_UrlImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1008,7 +1105,9 @@ class _$SuccessActionProcessed_UrlImpl extends SuccessActionProcessed_Url {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$SuccessActionProcessed_UrlImplCopyWith<_$SuccessActionProcessed_UrlImpl> get copyWith =>
@@ -1021,7 +1120,10 @@ abstract class SuccessActionProcessed_Url extends SuccessActionProcessed {
   const SuccessActionProcessed_Url._() : super._();
 
   UrlSuccessActionData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of SuccessActionProcessed
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$SuccessActionProcessed_UrlImplCopyWith<_$SuccessActionProcessed_UrlImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/dart/lib/src/bindings/duplicates.freezed.dart
+++ b/packages/dart/lib/src/bindings/duplicates.freezed.dart
@@ -18,7 +18,9 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$LnUrlAuthError {
   String get err => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $LnUrlAuthErrorCopyWith<LnUrlAuthError> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -40,6 +42,8 @@ class _$LnUrlAuthErrorCopyWithImpl<$Res, $Val extends LnUrlAuthError>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -72,6 +76,8 @@ class __$$LnUrlAuthError_GenericImplCopyWithImpl<$Res>
       _$LnUrlAuthError_GenericImpl _value, $Res Function(_$LnUrlAuthError_GenericImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -110,7 +116,9 @@ class _$LnUrlAuthError_GenericImpl extends LnUrlAuthError_Generic {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlAuthError_GenericImplCopyWith<_$LnUrlAuthError_GenericImpl> get copyWith =>
@@ -123,8 +131,11 @@ abstract class LnUrlAuthError_Generic extends LnUrlAuthError {
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlAuthError_GenericImplCopyWith<_$LnUrlAuthError_GenericImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -147,6 +158,8 @@ class __$$LnUrlAuthError_InvalidUriImplCopyWithImpl<$Res>
       _$LnUrlAuthError_InvalidUriImpl _value, $Res Function(_$LnUrlAuthError_InvalidUriImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -185,7 +198,9 @@ class _$LnUrlAuthError_InvalidUriImpl extends LnUrlAuthError_InvalidUri {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlAuthError_InvalidUriImplCopyWith<_$LnUrlAuthError_InvalidUriImpl> get copyWith =>
@@ -198,8 +213,11 @@ abstract class LnUrlAuthError_InvalidUri extends LnUrlAuthError {
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlAuthError_InvalidUriImplCopyWith<_$LnUrlAuthError_InvalidUriImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -223,6 +241,8 @@ class __$$LnUrlAuthError_ServiceConnectivityImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlAuthError_ServiceConnectivityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -261,7 +281,9 @@ class _$LnUrlAuthError_ServiceConnectivityImpl extends LnUrlAuthError_ServiceCon
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlAuthError_ServiceConnectivityImplCopyWith<_$LnUrlAuthError_ServiceConnectivityImpl> get copyWith =>
@@ -276,8 +298,11 @@ abstract class LnUrlAuthError_ServiceConnectivity extends LnUrlAuthError {
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlAuthError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlAuthError_ServiceConnectivityImplCopyWith<_$LnUrlAuthError_ServiceConnectivityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -300,6 +325,9 @@ class _$LnUrlCallbackStatusCopyWithImpl<$Res, $Val extends LnUrlCallbackStatus>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of LnUrlCallbackStatus
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -316,6 +344,9 @@ class __$$LnUrlCallbackStatus_OkImplCopyWithImpl<$Res>
   __$$LnUrlCallbackStatus_OkImplCopyWithImpl(
       _$LnUrlCallbackStatus_OkImpl _value, $Res Function(_$LnUrlCallbackStatus_OkImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of LnUrlCallbackStatus
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -360,6 +391,8 @@ class __$$LnUrlCallbackStatus_ErrorStatusImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlCallbackStatus_ErrorStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlCallbackStatus
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -398,7 +431,9 @@ class _$LnUrlCallbackStatus_ErrorStatusImpl extends LnUrlCallbackStatus_ErrorSta
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlCallbackStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlCallbackStatus_ErrorStatusImplCopyWith<_$LnUrlCallbackStatus_ErrorStatusImpl> get copyWith =>
@@ -412,7 +447,10 @@ abstract class LnUrlCallbackStatus_ErrorStatus extends LnUrlCallbackStatus {
   const LnUrlCallbackStatus_ErrorStatus._() : super._();
 
   LnUrlErrorData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlCallbackStatus
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlCallbackStatus_ErrorStatusImplCopyWith<_$LnUrlCallbackStatus_ErrorStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -434,6 +472,9 @@ class _$LnUrlPayErrorCopyWithImpl<$Res, $Val extends LnUrlPayError> implements $
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -450,6 +491,9 @@ class __$$LnUrlPayError_AlreadyPaidImplCopyWithImpl<$Res>
   __$$LnUrlPayError_AlreadyPaidImplCopyWithImpl(
       _$LnUrlPayError_AlreadyPaidImpl _value, $Res Function(_$LnUrlPayError_AlreadyPaidImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -494,6 +538,8 @@ class __$$LnUrlPayError_GenericImplCopyWithImpl<$Res>
       _$LnUrlPayError_GenericImpl _value, $Res Function(_$LnUrlPayError_GenericImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -532,7 +578,9 @@ class _$LnUrlPayError_GenericImpl extends LnUrlPayError_Generic {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_GenericImplCopyWith<_$LnUrlPayError_GenericImpl> get copyWith =>
@@ -544,7 +592,10 @@ abstract class LnUrlPayError_Generic extends LnUrlPayError {
   const LnUrlPayError_Generic._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_GenericImplCopyWith<_$LnUrlPayError_GenericImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -566,6 +617,8 @@ class __$$LnUrlPayError_InvalidAmountImplCopyWithImpl<$Res>
       _$LnUrlPayError_InvalidAmountImpl _value, $Res Function(_$LnUrlPayError_InvalidAmountImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -604,7 +657,9 @@ class _$LnUrlPayError_InvalidAmountImpl extends LnUrlPayError_InvalidAmount {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_InvalidAmountImplCopyWith<_$LnUrlPayError_InvalidAmountImpl> get copyWith =>
@@ -616,7 +671,10 @@ abstract class LnUrlPayError_InvalidAmount extends LnUrlPayError {
   const LnUrlPayError_InvalidAmount._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_InvalidAmountImplCopyWith<_$LnUrlPayError_InvalidAmountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -638,6 +696,8 @@ class __$$LnUrlPayError_InvalidInvoiceImplCopyWithImpl<$Res>
       _$LnUrlPayError_InvalidInvoiceImpl _value, $Res Function(_$LnUrlPayError_InvalidInvoiceImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -676,7 +736,9 @@ class _$LnUrlPayError_InvalidInvoiceImpl extends LnUrlPayError_InvalidInvoice {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_InvalidInvoiceImplCopyWith<_$LnUrlPayError_InvalidInvoiceImpl> get copyWith =>
@@ -689,7 +751,10 @@ abstract class LnUrlPayError_InvalidInvoice extends LnUrlPayError {
   const LnUrlPayError_InvalidInvoice._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_InvalidInvoiceImplCopyWith<_$LnUrlPayError_InvalidInvoiceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -711,6 +776,8 @@ class __$$LnUrlPayError_InvalidNetworkImplCopyWithImpl<$Res>
       _$LnUrlPayError_InvalidNetworkImpl _value, $Res Function(_$LnUrlPayError_InvalidNetworkImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -749,7 +816,9 @@ class _$LnUrlPayError_InvalidNetworkImpl extends LnUrlPayError_InvalidNetwork {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_InvalidNetworkImplCopyWith<_$LnUrlPayError_InvalidNetworkImpl> get copyWith =>
@@ -762,7 +831,10 @@ abstract class LnUrlPayError_InvalidNetwork extends LnUrlPayError {
   const LnUrlPayError_InvalidNetwork._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_InvalidNetworkImplCopyWith<_$LnUrlPayError_InvalidNetworkImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -784,6 +856,8 @@ class __$$LnUrlPayError_InvalidUriImplCopyWithImpl<$Res>
       _$LnUrlPayError_InvalidUriImpl _value, $Res Function(_$LnUrlPayError_InvalidUriImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -822,7 +896,9 @@ class _$LnUrlPayError_InvalidUriImpl extends LnUrlPayError_InvalidUri {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_InvalidUriImplCopyWith<_$LnUrlPayError_InvalidUriImpl> get copyWith =>
@@ -834,7 +910,10 @@ abstract class LnUrlPayError_InvalidUri extends LnUrlPayError {
   const LnUrlPayError_InvalidUri._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_InvalidUriImplCopyWith<_$LnUrlPayError_InvalidUriImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -856,6 +935,8 @@ class __$$LnUrlPayError_InvoiceExpiredImplCopyWithImpl<$Res>
       _$LnUrlPayError_InvoiceExpiredImpl _value, $Res Function(_$LnUrlPayError_InvoiceExpiredImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -894,7 +975,9 @@ class _$LnUrlPayError_InvoiceExpiredImpl extends LnUrlPayError_InvoiceExpired {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_InvoiceExpiredImplCopyWith<_$LnUrlPayError_InvoiceExpiredImpl> get copyWith =>
@@ -907,7 +990,10 @@ abstract class LnUrlPayError_InvoiceExpired extends LnUrlPayError {
   const LnUrlPayError_InvoiceExpired._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_InvoiceExpiredImplCopyWith<_$LnUrlPayError_InvoiceExpiredImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -929,6 +1015,8 @@ class __$$LnUrlPayError_PaymentFailedImplCopyWithImpl<$Res>
       _$LnUrlPayError_PaymentFailedImpl _value, $Res Function(_$LnUrlPayError_PaymentFailedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -967,7 +1055,9 @@ class _$LnUrlPayError_PaymentFailedImpl extends LnUrlPayError_PaymentFailed {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_PaymentFailedImplCopyWith<_$LnUrlPayError_PaymentFailedImpl> get copyWith =>
@@ -979,7 +1069,10 @@ abstract class LnUrlPayError_PaymentFailed extends LnUrlPayError {
   const LnUrlPayError_PaymentFailed._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_PaymentFailedImplCopyWith<_$LnUrlPayError_PaymentFailedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1001,6 +1094,8 @@ class __$$LnUrlPayError_PaymentTimeoutImplCopyWithImpl<$Res>
       _$LnUrlPayError_PaymentTimeoutImpl _value, $Res Function(_$LnUrlPayError_PaymentTimeoutImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1039,7 +1134,9 @@ class _$LnUrlPayError_PaymentTimeoutImpl extends LnUrlPayError_PaymentTimeout {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_PaymentTimeoutImplCopyWith<_$LnUrlPayError_PaymentTimeoutImpl> get copyWith =>
@@ -1052,7 +1149,10 @@ abstract class LnUrlPayError_PaymentTimeout extends LnUrlPayError {
   const LnUrlPayError_PaymentTimeout._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_PaymentTimeoutImplCopyWith<_$LnUrlPayError_PaymentTimeoutImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1074,6 +1174,8 @@ class __$$LnUrlPayError_RouteNotFoundImplCopyWithImpl<$Res>
       _$LnUrlPayError_RouteNotFoundImpl _value, $Res Function(_$LnUrlPayError_RouteNotFoundImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1112,7 +1214,9 @@ class _$LnUrlPayError_RouteNotFoundImpl extends LnUrlPayError_RouteNotFound {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_RouteNotFoundImplCopyWith<_$LnUrlPayError_RouteNotFoundImpl> get copyWith =>
@@ -1124,7 +1228,10 @@ abstract class LnUrlPayError_RouteNotFound extends LnUrlPayError {
   const LnUrlPayError_RouteNotFound._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_RouteNotFoundImplCopyWith<_$LnUrlPayError_RouteNotFoundImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1146,6 +1253,8 @@ class __$$LnUrlPayError_RouteTooExpensiveImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlPayError_RouteTooExpensiveImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1184,7 +1293,9 @@ class _$LnUrlPayError_RouteTooExpensiveImpl extends LnUrlPayError_RouteTooExpens
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_RouteTooExpensiveImplCopyWith<_$LnUrlPayError_RouteTooExpensiveImpl> get copyWith =>
@@ -1198,7 +1309,10 @@ abstract class LnUrlPayError_RouteTooExpensive extends LnUrlPayError {
   const LnUrlPayError_RouteTooExpensive._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_RouteTooExpensiveImplCopyWith<_$LnUrlPayError_RouteTooExpensiveImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1220,6 +1334,8 @@ class __$$LnUrlPayError_ServiceConnectivityImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlPayError_ServiceConnectivityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1258,7 +1374,9 @@ class _$LnUrlPayError_ServiceConnectivityImpl extends LnUrlPayError_ServiceConne
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayError_ServiceConnectivityImplCopyWith<_$LnUrlPayError_ServiceConnectivityImpl> get copyWith =>
@@ -1272,7 +1390,10 @@ abstract class LnUrlPayError_ServiceConnectivity extends LnUrlPayError {
   const LnUrlPayError_ServiceConnectivity._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayError_ServiceConnectivityImplCopyWith<_$LnUrlPayError_ServiceConnectivityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1281,7 +1402,9 @@ abstract class LnUrlPayError_ServiceConnectivity extends LnUrlPayError {
 mixin _$LnUrlWithdrawError {
   String get err => throw _privateConstructorUsedError;
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $LnUrlWithdrawErrorCopyWith<LnUrlWithdrawError> get copyWith => throw _privateConstructorUsedError;
 }
 
@@ -1303,6 +1426,8 @@ class _$LnUrlWithdrawErrorCopyWithImpl<$Res, $Val extends LnUrlWithdrawError>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1335,6 +1460,8 @@ class __$$LnUrlWithdrawError_GenericImplCopyWithImpl<$Res>
       _$LnUrlWithdrawError_GenericImpl _value, $Res Function(_$LnUrlWithdrawError_GenericImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1373,7 +1500,9 @@ class _$LnUrlWithdrawError_GenericImpl extends LnUrlWithdrawError_Generic {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawError_GenericImplCopyWith<_$LnUrlWithdrawError_GenericImpl> get copyWith =>
@@ -1386,8 +1515,11 @@ abstract class LnUrlWithdrawError_Generic extends LnUrlWithdrawError {
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawError_GenericImplCopyWith<_$LnUrlWithdrawError_GenericImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1411,6 +1543,8 @@ class __$$LnUrlWithdrawError_InvalidAmountImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlWithdrawError_InvalidAmountImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1449,7 +1583,9 @@ class _$LnUrlWithdrawError_InvalidAmountImpl extends LnUrlWithdrawError_InvalidA
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawError_InvalidAmountImplCopyWith<_$LnUrlWithdrawError_InvalidAmountImpl> get copyWith =>
@@ -1464,8 +1600,11 @@ abstract class LnUrlWithdrawError_InvalidAmount extends LnUrlWithdrawError {
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawError_InvalidAmountImplCopyWith<_$LnUrlWithdrawError_InvalidAmountImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1489,6 +1628,8 @@ class __$$LnUrlWithdrawError_InvalidInvoiceImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlWithdrawError_InvalidInvoiceImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1527,7 +1668,9 @@ class _$LnUrlWithdrawError_InvalidInvoiceImpl extends LnUrlWithdrawError_Invalid
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawError_InvalidInvoiceImplCopyWith<_$LnUrlWithdrawError_InvalidInvoiceImpl> get copyWith =>
@@ -1542,8 +1685,11 @@ abstract class LnUrlWithdrawError_InvalidInvoice extends LnUrlWithdrawError {
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawError_InvalidInvoiceImplCopyWith<_$LnUrlWithdrawError_InvalidInvoiceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1567,6 +1713,8 @@ class __$$LnUrlWithdrawError_InvalidUriImplCopyWithImpl<$Res>
       _$LnUrlWithdrawError_InvalidUriImpl _value, $Res Function(_$LnUrlWithdrawError_InvalidUriImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1605,7 +1753,9 @@ class _$LnUrlWithdrawError_InvalidUriImpl extends LnUrlWithdrawError_InvalidUri 
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawError_InvalidUriImplCopyWith<_$LnUrlWithdrawError_InvalidUriImpl> get copyWith =>
@@ -1620,8 +1770,11 @@ abstract class LnUrlWithdrawError_InvalidUri extends LnUrlWithdrawError {
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawError_InvalidUriImplCopyWith<_$LnUrlWithdrawError_InvalidUriImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1647,6 +1800,8 @@ class __$$LnUrlWithdrawError_InvoiceNoRoutingHintsImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlWithdrawError_InvoiceNoRoutingHintsImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1685,7 +1840,9 @@ class _$LnUrlWithdrawError_InvoiceNoRoutingHintsImpl extends LnUrlWithdrawError_
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawError_InvoiceNoRoutingHintsImplCopyWith<_$LnUrlWithdrawError_InvoiceNoRoutingHintsImpl>
@@ -1700,8 +1857,11 @@ abstract class LnUrlWithdrawError_InvoiceNoRoutingHints extends LnUrlWithdrawErr
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawError_InvoiceNoRoutingHintsImplCopyWith<_$LnUrlWithdrawError_InvoiceNoRoutingHintsImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1727,6 +1887,8 @@ class __$$LnUrlWithdrawError_ServiceConnectivityImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlWithdrawError_ServiceConnectivityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1765,7 +1927,9 @@ class _$LnUrlWithdrawError_ServiceConnectivityImpl extends LnUrlWithdrawError_Se
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawError_ServiceConnectivityImplCopyWith<_$LnUrlWithdrawError_ServiceConnectivityImpl>
@@ -1780,8 +1944,11 @@ abstract class LnUrlWithdrawError_ServiceConnectivity extends LnUrlWithdrawError
 
   @override
   String get err;
+
+  /// Create a copy of LnUrlWithdrawError
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawError_ServiceConnectivityImplCopyWith<_$LnUrlWithdrawError_ServiceConnectivityImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -1806,6 +1973,9 @@ class _$LnUrlWithdrawResultCopyWithImpl<$Res, $Val extends LnUrlWithdrawResult>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1825,6 +1995,8 @@ class __$$LnUrlWithdrawResult_OkImplCopyWithImpl<$Res>
       _$LnUrlWithdrawResult_OkImpl _value, $Res Function(_$LnUrlWithdrawResult_OkImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1863,7 +2035,9 @@ class _$LnUrlWithdrawResult_OkImpl extends LnUrlWithdrawResult_Ok {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawResult_OkImplCopyWith<_$LnUrlWithdrawResult_OkImpl> get copyWith =>
@@ -1877,7 +2051,10 @@ abstract class LnUrlWithdrawResult_Ok extends LnUrlWithdrawResult {
 
   @override
   LnUrlWithdrawSuccessData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawResult_OkImplCopyWith<_$LnUrlWithdrawResult_OkImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1899,6 +2076,8 @@ class __$$LnUrlWithdrawResult_TimeoutImplCopyWithImpl<$Res>
       _$LnUrlWithdrawResult_TimeoutImpl _value, $Res Function(_$LnUrlWithdrawResult_TimeoutImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1937,7 +2116,9 @@ class _$LnUrlWithdrawResult_TimeoutImpl extends LnUrlWithdrawResult_Timeout {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawResult_TimeoutImplCopyWith<_$LnUrlWithdrawResult_TimeoutImpl> get copyWith =>
@@ -1951,7 +2132,10 @@ abstract class LnUrlWithdrawResult_Timeout extends LnUrlWithdrawResult {
 
   @override
   LnUrlWithdrawSuccessData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawResult_TimeoutImplCopyWith<_$LnUrlWithdrawResult_TimeoutImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1973,6 +2157,8 @@ class __$$LnUrlWithdrawResult_ErrorStatusImplCopyWithImpl<$Res>
       $Res Function(_$LnUrlWithdrawResult_ErrorStatusImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -2011,7 +2197,9 @@ class _$LnUrlWithdrawResult_ErrorStatusImpl extends LnUrlWithdrawResult_ErrorSta
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlWithdrawResult_ErrorStatusImplCopyWith<_$LnUrlWithdrawResult_ErrorStatusImpl> get copyWith =>
@@ -2026,7 +2214,10 @@ abstract class LnUrlWithdrawResult_ErrorStatus extends LnUrlWithdrawResult {
 
   @override
   LnUrlErrorData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlWithdrawResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlWithdrawResult_ErrorStatusImplCopyWith<_$LnUrlWithdrawResult_ErrorStatusImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/dart/lib/src/error.freezed.dart
+++ b/packages/dart/lib/src/error.freezed.dart
@@ -32,6 +32,9 @@ class _$LiquidSdkErrorCopyWithImpl<$Res, $Val extends LiquidSdkError>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -48,6 +51,9 @@ class __$$LiquidSdkError_AlreadyStartedImplCopyWithImpl<$Res>
   __$$LiquidSdkError_AlreadyStartedImplCopyWithImpl(
       _$LiquidSdkError_AlreadyStartedImpl _value, $Res Function(_$LiquidSdkError_AlreadyStartedImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -92,6 +98,8 @@ class __$$LiquidSdkError_GenericImplCopyWithImpl<$Res>
       _$LiquidSdkError_GenericImpl _value, $Res Function(_$LiquidSdkError_GenericImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -130,7 +138,9 @@ class _$LiquidSdkError_GenericImpl extends LiquidSdkError_Generic {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiquidSdkError_GenericImplCopyWith<_$LiquidSdkError_GenericImpl> get copyWith =>
@@ -142,7 +152,10 @@ abstract class LiquidSdkError_Generic extends LiquidSdkError {
   const LiquidSdkError_Generic._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiquidSdkError_GenericImplCopyWith<_$LiquidSdkError_GenericImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -161,6 +174,9 @@ class __$$LiquidSdkError_NotStartedImplCopyWithImpl<$Res>
   __$$LiquidSdkError_NotStartedImplCopyWithImpl(
       _$LiquidSdkError_NotStartedImpl _value, $Res Function(_$LiquidSdkError_NotStartedImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -205,6 +221,8 @@ class __$$LiquidSdkError_ServiceConnectivityImplCopyWithImpl<$Res>
       $Res Function(_$LiquidSdkError_ServiceConnectivityImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -243,7 +261,9 @@ class _$LiquidSdkError_ServiceConnectivityImpl extends LiquidSdkError_ServiceCon
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiquidSdkError_ServiceConnectivityImplCopyWith<_$LiquidSdkError_ServiceConnectivityImpl> get copyWith =>
@@ -257,7 +277,10 @@ abstract class LiquidSdkError_ServiceConnectivity extends LiquidSdkError {
   const LiquidSdkError_ServiceConnectivity._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiquidSdkError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiquidSdkError_ServiceConnectivityImplCopyWith<_$LiquidSdkError_ServiceConnectivityImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -279,6 +302,9 @@ class _$PaymentErrorCopyWithImpl<$Res, $Val extends PaymentError> implements $Pa
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -295,6 +321,9 @@ class __$$PaymentError_AlreadyClaimedImplCopyWithImpl<$Res>
   __$$PaymentError_AlreadyClaimedImplCopyWithImpl(
       _$PaymentError_AlreadyClaimedImpl _value, $Res Function(_$PaymentError_AlreadyClaimedImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -336,6 +365,9 @@ class __$$PaymentError_AlreadyPaidImplCopyWithImpl<$Res>
   __$$PaymentError_AlreadyPaidImplCopyWithImpl(
       _$PaymentError_AlreadyPaidImpl _value, $Res Function(_$PaymentError_AlreadyPaidImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -377,6 +409,9 @@ class __$$PaymentError_PaymentInProgressImplCopyWithImpl<$Res>
   __$$PaymentError_PaymentInProgressImplCopyWithImpl(
       _$PaymentError_PaymentInProgressImpl _value, $Res Function(_$PaymentError_PaymentInProgressImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -418,6 +453,9 @@ class __$$PaymentError_AmountOutOfRangeImplCopyWithImpl<$Res>
   __$$PaymentError_AmountOutOfRangeImplCopyWithImpl(
       _$PaymentError_AmountOutOfRangeImpl _value, $Res Function(_$PaymentError_AmountOutOfRangeImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -462,6 +500,8 @@ class __$$PaymentError_GenericImplCopyWithImpl<$Res>
       _$PaymentError_GenericImpl _value, $Res Function(_$PaymentError_GenericImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -500,7 +540,9 @@ class _$PaymentError_GenericImpl extends PaymentError_Generic {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentError_GenericImplCopyWith<_$PaymentError_GenericImpl> get copyWith =>
@@ -512,7 +554,10 @@ abstract class PaymentError_Generic extends PaymentError {
   const PaymentError_Generic._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentError_GenericImplCopyWith<_$PaymentError_GenericImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -531,6 +576,9 @@ class __$$PaymentError_InvalidOrExpiredFeesImplCopyWithImpl<$Res>
   __$$PaymentError_InvalidOrExpiredFeesImplCopyWithImpl(_$PaymentError_InvalidOrExpiredFeesImpl _value,
       $Res Function(_$PaymentError_InvalidOrExpiredFeesImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -572,6 +620,9 @@ class __$$PaymentError_InsufficientFundsImplCopyWithImpl<$Res>
   __$$PaymentError_InsufficientFundsImplCopyWithImpl(
       _$PaymentError_InsufficientFundsImpl _value, $Res Function(_$PaymentError_InsufficientFundsImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -616,6 +667,8 @@ class __$$PaymentError_InvalidInvoiceImplCopyWithImpl<$Res>
       _$PaymentError_InvalidInvoiceImpl _value, $Res Function(_$PaymentError_InvalidInvoiceImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -654,7 +707,9 @@ class _$PaymentError_InvalidInvoiceImpl extends PaymentError_InvalidInvoice {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentError_InvalidInvoiceImplCopyWith<_$PaymentError_InvalidInvoiceImpl> get copyWith =>
@@ -666,7 +721,10 @@ abstract class PaymentError_InvalidInvoice extends PaymentError {
   const PaymentError_InvalidInvoice._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentError_InvalidInvoiceImplCopyWith<_$PaymentError_InvalidInvoiceImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -685,6 +743,9 @@ class __$$PaymentError_InvalidPreimageImplCopyWithImpl<$Res>
   __$$PaymentError_InvalidPreimageImplCopyWithImpl(
       _$PaymentError_InvalidPreimageImpl _value, $Res Function(_$PaymentError_InvalidPreimageImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -729,6 +790,8 @@ class __$$PaymentError_LwkErrorImplCopyWithImpl<$Res>
       _$PaymentError_LwkErrorImpl _value, $Res Function(_$PaymentError_LwkErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -767,7 +830,9 @@ class _$PaymentError_LwkErrorImpl extends PaymentError_LwkError {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentError_LwkErrorImplCopyWith<_$PaymentError_LwkErrorImpl> get copyWith =>
@@ -779,7 +844,10 @@ abstract class PaymentError_LwkError extends PaymentError {
   const PaymentError_LwkError._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentError_LwkErrorImplCopyWith<_$PaymentError_LwkErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -798,6 +866,9 @@ class __$$PaymentError_PairsNotFoundImplCopyWithImpl<$Res>
   __$$PaymentError_PairsNotFoundImplCopyWithImpl(
       _$PaymentError_PairsNotFoundImpl _value, $Res Function(_$PaymentError_PairsNotFoundImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -839,6 +910,9 @@ class __$$PaymentError_PaymentTimeoutImplCopyWithImpl<$Res>
   __$$PaymentError_PaymentTimeoutImplCopyWithImpl(
       _$PaymentError_PaymentTimeoutImpl _value, $Res Function(_$PaymentError_PaymentTimeoutImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -880,6 +954,9 @@ class __$$PaymentError_PersistErrorImplCopyWithImpl<$Res>
   __$$PaymentError_PersistErrorImplCopyWithImpl(
       _$PaymentError_PersistErrorImpl _value, $Res Function(_$PaymentError_PersistErrorImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -924,6 +1001,8 @@ class __$$PaymentError_ReceiveErrorImplCopyWithImpl<$Res>
       _$PaymentError_ReceiveErrorImpl _value, $Res Function(_$PaymentError_ReceiveErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -962,7 +1041,9 @@ class _$PaymentError_ReceiveErrorImpl extends PaymentError_ReceiveError {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentError_ReceiveErrorImplCopyWith<_$PaymentError_ReceiveErrorImpl> get copyWith =>
@@ -974,7 +1055,10 @@ abstract class PaymentError_ReceiveError extends PaymentError {
   const PaymentError_ReceiveError._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentError_ReceiveErrorImplCopyWith<_$PaymentError_ReceiveErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -996,6 +1080,8 @@ class __$$PaymentError_RefundedImplCopyWithImpl<$Res>
       _$PaymentError_RefundedImpl _value, $Res Function(_$PaymentError_RefundedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1042,7 +1128,9 @@ class _$PaymentError_RefundedImpl extends PaymentError_Refunded {
   @override
   int get hashCode => Object.hash(runtimeType, err, refundTxId);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentError_RefundedImplCopyWith<_$PaymentError_RefundedImpl> get copyWith =>
@@ -1056,7 +1144,10 @@ abstract class PaymentError_Refunded extends PaymentError {
 
   String get err;
   String get refundTxId;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentError_RefundedImplCopyWith<_$PaymentError_RefundedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1077,6 +1168,9 @@ class __$$PaymentError_SelfTransferNotSupportedImplCopyWithImpl<$Res>
       _$PaymentError_SelfTransferNotSupportedImpl _value,
       $Res Function(_$PaymentError_SelfTransferNotSupportedImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -1121,6 +1215,8 @@ class __$$PaymentError_SendErrorImplCopyWithImpl<$Res>
       _$PaymentError_SendErrorImpl _value, $Res Function(_$PaymentError_SendErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1159,7 +1255,9 @@ class _$PaymentError_SendErrorImpl extends PaymentError_SendError {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentError_SendErrorImplCopyWith<_$PaymentError_SendErrorImpl> get copyWith =>
@@ -1171,7 +1269,10 @@ abstract class PaymentError_SendError extends PaymentError {
   const PaymentError_SendError._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentError_SendErrorImplCopyWith<_$PaymentError_SendErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -1193,6 +1294,8 @@ class __$$PaymentError_SignerErrorImplCopyWithImpl<$Res>
       _$PaymentError_SignerErrorImpl _value, $Res Function(_$PaymentError_SignerErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -1231,7 +1334,9 @@ class _$PaymentError_SignerErrorImpl extends PaymentError_SignerError {
   @override
   int get hashCode => Object.hash(runtimeType, err);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$PaymentError_SignerErrorImplCopyWith<_$PaymentError_SignerErrorImpl> get copyWith =>
@@ -1243,7 +1348,10 @@ abstract class PaymentError_SignerError extends PaymentError {
   const PaymentError_SignerError._() : super._();
 
   String get err;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of PaymentError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$PaymentError_SignerErrorImplCopyWith<_$PaymentError_SignerErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/dart/lib/src/model.freezed.dart
+++ b/packages/dart/lib/src/model.freezed.dart
@@ -32,6 +32,9 @@ class _$LiquidSdkEventCopyWithImpl<$Res, $Val extends LiquidSdkEvent>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -51,6 +54,8 @@ class __$$LiquidSdkEvent_PaymentFailedImplCopyWithImpl<$Res>
       _$LiquidSdkEvent_PaymentFailedImpl _value, $Res Function(_$LiquidSdkEvent_PaymentFailedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -89,7 +94,9 @@ class _$LiquidSdkEvent_PaymentFailedImpl extends LiquidSdkEvent_PaymentFailed {
   @override
   int get hashCode => Object.hash(runtimeType, details);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiquidSdkEvent_PaymentFailedImplCopyWith<_$LiquidSdkEvent_PaymentFailedImpl> get copyWith =>
@@ -102,7 +109,10 @@ abstract class LiquidSdkEvent_PaymentFailed extends LiquidSdkEvent {
   const LiquidSdkEvent_PaymentFailed._() : super._();
 
   Payment get details;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiquidSdkEvent_PaymentFailedImplCopyWith<_$LiquidSdkEvent_PaymentFailedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -124,6 +134,8 @@ class __$$LiquidSdkEvent_PaymentPendingImplCopyWithImpl<$Res>
       _$LiquidSdkEvent_PaymentPendingImpl _value, $Res Function(_$LiquidSdkEvent_PaymentPendingImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -162,7 +174,9 @@ class _$LiquidSdkEvent_PaymentPendingImpl extends LiquidSdkEvent_PaymentPending 
   @override
   int get hashCode => Object.hash(runtimeType, details);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiquidSdkEvent_PaymentPendingImplCopyWith<_$LiquidSdkEvent_PaymentPendingImpl> get copyWith =>
@@ -176,7 +190,10 @@ abstract class LiquidSdkEvent_PaymentPending extends LiquidSdkEvent {
   const LiquidSdkEvent_PaymentPending._() : super._();
 
   Payment get details;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiquidSdkEvent_PaymentPendingImplCopyWith<_$LiquidSdkEvent_PaymentPendingImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -198,6 +215,8 @@ class __$$LiquidSdkEvent_PaymentRefundedImplCopyWithImpl<$Res>
       _$LiquidSdkEvent_PaymentRefundedImpl _value, $Res Function(_$LiquidSdkEvent_PaymentRefundedImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -236,7 +255,9 @@ class _$LiquidSdkEvent_PaymentRefundedImpl extends LiquidSdkEvent_PaymentRefunde
   @override
   int get hashCode => Object.hash(runtimeType, details);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiquidSdkEvent_PaymentRefundedImplCopyWith<_$LiquidSdkEvent_PaymentRefundedImpl> get copyWith =>
@@ -250,7 +271,10 @@ abstract class LiquidSdkEvent_PaymentRefunded extends LiquidSdkEvent {
   const LiquidSdkEvent_PaymentRefunded._() : super._();
 
   Payment get details;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiquidSdkEvent_PaymentRefundedImplCopyWith<_$LiquidSdkEvent_PaymentRefundedImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -272,6 +296,8 @@ class __$$LiquidSdkEvent_PaymentRefundPendingImplCopyWithImpl<$Res>
       $Res Function(_$LiquidSdkEvent_PaymentRefundPendingImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -310,7 +336,9 @@ class _$LiquidSdkEvent_PaymentRefundPendingImpl extends LiquidSdkEvent_PaymentRe
   @override
   int get hashCode => Object.hash(runtimeType, details);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiquidSdkEvent_PaymentRefundPendingImplCopyWith<_$LiquidSdkEvent_PaymentRefundPendingImpl>
@@ -325,7 +353,10 @@ abstract class LiquidSdkEvent_PaymentRefundPending extends LiquidSdkEvent {
   const LiquidSdkEvent_PaymentRefundPending._() : super._();
 
   Payment get details;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiquidSdkEvent_PaymentRefundPendingImplCopyWith<_$LiquidSdkEvent_PaymentRefundPendingImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -347,6 +378,8 @@ class __$$LiquidSdkEvent_PaymentSucceededImplCopyWithImpl<$Res>
       $Res Function(_$LiquidSdkEvent_PaymentSucceededImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -385,7 +418,9 @@ class _$LiquidSdkEvent_PaymentSucceededImpl extends LiquidSdkEvent_PaymentSuccee
   @override
   int get hashCode => Object.hash(runtimeType, details);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiquidSdkEvent_PaymentSucceededImplCopyWith<_$LiquidSdkEvent_PaymentSucceededImpl> get copyWith =>
@@ -399,7 +434,10 @@ abstract class LiquidSdkEvent_PaymentSucceeded extends LiquidSdkEvent {
   const LiquidSdkEvent_PaymentSucceeded._() : super._();
 
   Payment get details;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiquidSdkEvent_PaymentSucceededImplCopyWith<_$LiquidSdkEvent_PaymentSucceededImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -423,6 +461,8 @@ class __$$LiquidSdkEvent_PaymentWaitingConfirmationImplCopyWithImpl<$Res>
       $Res Function(_$LiquidSdkEvent_PaymentWaitingConfirmationImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -461,7 +501,9 @@ class _$LiquidSdkEvent_PaymentWaitingConfirmationImpl extends LiquidSdkEvent_Pay
   @override
   int get hashCode => Object.hash(runtimeType, details);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LiquidSdkEvent_PaymentWaitingConfirmationImplCopyWith<_$LiquidSdkEvent_PaymentWaitingConfirmationImpl>
@@ -475,7 +517,10 @@ abstract class LiquidSdkEvent_PaymentWaitingConfirmation extends LiquidSdkEvent 
   const LiquidSdkEvent_PaymentWaitingConfirmation._() : super._();
 
   Payment get details;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LiquidSdkEvent_PaymentWaitingConfirmationImplCopyWith<_$LiquidSdkEvent_PaymentWaitingConfirmationImpl>
       get copyWith => throw _privateConstructorUsedError;
 }
@@ -494,6 +539,9 @@ class __$$LiquidSdkEvent_SyncedImplCopyWithImpl<$Res>
   __$$LiquidSdkEvent_SyncedImplCopyWithImpl(
       _$LiquidSdkEvent_SyncedImpl _value, $Res Function(_$LiquidSdkEvent_SyncedImpl) _then)
       : super(_value, _then);
+
+  /// Create a copy of LiquidSdkEvent
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -541,6 +589,9 @@ class _$LnUrlPayResultCopyWithImpl<$Res, $Val extends LnUrlPayResult>
   final $Val _value;
   // ignore: unused_field
   final $Res Function($Val) _then;
+
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
 }
 
 /// @nodoc
@@ -560,6 +611,8 @@ class __$$LnUrlPayResult_EndpointSuccessImplCopyWithImpl<$Res>
       _$LnUrlPayResult_EndpointSuccessImpl _value, $Res Function(_$LnUrlPayResult_EndpointSuccessImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -598,7 +651,9 @@ class _$LnUrlPayResult_EndpointSuccessImpl extends LnUrlPayResult_EndpointSucces
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayResult_EndpointSuccessImplCopyWith<_$LnUrlPayResult_EndpointSuccessImpl> get copyWith =>
@@ -613,7 +668,10 @@ abstract class LnUrlPayResult_EndpointSuccess extends LnUrlPayResult {
 
   @override
   LnUrlPaySuccessData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayResult_EndpointSuccessImplCopyWith<_$LnUrlPayResult_EndpointSuccessImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -635,6 +693,8 @@ class __$$LnUrlPayResult_EndpointErrorImplCopyWithImpl<$Res>
       _$LnUrlPayResult_EndpointErrorImpl _value, $Res Function(_$LnUrlPayResult_EndpointErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -673,7 +733,9 @@ class _$LnUrlPayResult_EndpointErrorImpl extends LnUrlPayResult_EndpointError {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayResult_EndpointErrorImplCopyWith<_$LnUrlPayResult_EndpointErrorImpl> get copyWith =>
@@ -687,7 +749,10 @@ abstract class LnUrlPayResult_EndpointError extends LnUrlPayResult {
 
   @override
   LnUrlErrorData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayResult_EndpointErrorImplCopyWith<_$LnUrlPayResult_EndpointErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -709,6 +774,8 @@ class __$$LnUrlPayResult_PayErrorImplCopyWithImpl<$Res>
       _$LnUrlPayResult_PayErrorImpl _value, $Res Function(_$LnUrlPayResult_PayErrorImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -747,7 +814,9 @@ class _$LnUrlPayResult_PayErrorImpl extends LnUrlPayResult_PayError {
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$LnUrlPayResult_PayErrorImplCopyWith<_$LnUrlPayResult_PayErrorImpl> get copyWith =>
@@ -761,7 +830,10 @@ abstract class LnUrlPayResult_PayError extends LnUrlPayResult {
 
   @override
   LnUrlPayErrorData get data;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of LnUrlPayResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LnUrlPayResult_PayErrorImplCopyWith<_$LnUrlPayResult_PayErrorImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/packages/flutter/example/lib/main.dart
+++ b/packages/flutter/example/lib/main.dart
@@ -50,7 +50,7 @@ class _AppState extends State<App> {
     return MaterialApp(
       title: App.title,
       theme: ThemeData.from(colorScheme: ColorScheme.fromSeed(seedColor: Colors.white), useMaterial3: true),
-      home: widget.liquidSDK.wallet == null
+      home: widget.liquidSDK.instance == null
           ? ConnectPage(
               liquidSDK: widget.liquidSDK,
               credentialsManager: widget.credentialsManager,

--- a/packages/flutter/example/lib/routes/home/home_page.dart
+++ b/packages/flutter/example/lib/routes/home/home_page.dart
@@ -10,10 +10,14 @@ import 'package:flutter_breez_liquid_example/services/breez_liquid_sdk.dart';
 import 'package:flutter_breez_liquid_example/services/credentials_manager.dart';
 
 class HomePage extends StatefulWidget {
-  final CredentialsManager credentialsManager;
   final BreezLiquidSDK liquidSDK;
+  final CredentialsManager credentialsManager;
 
-  const HomePage({super.key, required this.credentialsManager, required this.liquidSDK});
+  const HomePage({
+    super.key,
+    required this.liquidSDK,
+    required this.credentialsManager,
+  });
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -65,11 +69,11 @@ class _HomePageState extends State<HomePage> {
           },
         ),
         drawer: HomePageDrawer(
-            liquidSDK: widget.liquidSDK.wallet!, credentialsManager: widget.credentialsManager),
-        floatingActionButton: QrActionButton(liquidSDK: widget.liquidSDK.wallet!),
+            liquidSDK: widget.liquidSDK.instance!, credentialsManager: widget.credentialsManager),
+        floatingActionButton: QrActionButton(liquidSDK: widget.liquidSDK.instance!),
         floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
         bottomNavigationBar: HomePageBottomAppBar(
-          liquidSDK: widget.liquidSDK.wallet!,
+          liquidSDK: widget.liquidSDK.instance!,
           paymentsStream: widget.liquidSDK.paymentsStream,
         ),
       ),
@@ -79,7 +83,7 @@ class _HomePageState extends State<HomePage> {
   Future<void> _sync() async {
     try {
       debugPrint("Syncing wallet.");
-      await widget.liquidSDK.wallet!.sync();
+      await widget.liquidSDK.instance!.sync();
       debugPrint("Wallet synced!");
     } on Exception catch (e) {
       final errMsg = "Failed to sync wallet. $e";

--- a/packages/flutter/example/lib/routes/home/widgets/drawer.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/drawer.dart
@@ -4,8 +4,8 @@ import 'package:flutter_breez_liquid_example/routes/home/widgets/mnemonics_dialo
 import 'package:flutter_breez_liquid_example/services/credentials_manager.dart';
 
 class HomePageDrawer extends StatefulWidget {
-  final CredentialsManager credentialsManager;
   final BindingLiquidSdk liquidSDK;
+  final CredentialsManager credentialsManager;
 
   const HomePageDrawer({super.key, required this.liquidSDK, required this.credentialsManager});
 

--- a/packages/flutter/example/lib/routes/home/widgets/send_payment/send_payment_dialog.dart
+++ b/packages/flutter/example/lib/routes/home/widgets/send_payment/send_payment_dialog.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 
 class SendPaymentDialog extends StatefulWidget {
-  final String? barcodeValue;
   final BindingLiquidSdk liquidSdk;
+  final String? barcodeValue;
 
   const SendPaymentDialog({super.key, required this.liquidSdk, this.barcodeValue});
 

--- a/packages/flutter/example/lib/services/breez_liquid_sdk.dart
+++ b/packages/flutter/example/lib/services/breez_liquid_sdk.dart
@@ -4,16 +4,16 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:rxdart/rxdart.dart';
 
 class BreezLiquidSDK {
-  liquid_sdk.BindingLiquidSdk? wallet;
+  liquid_sdk.BindingLiquidSdk? instance;
 
   Future<liquid_sdk.BindingLiquidSdk> connect({
     required liquid_sdk.ConnectRequest req,
   }) async {
-    wallet = await liquid_sdk.connect(req: req);
-    _initializeEventsStream(wallet!);
-    _subscribeToSdkStreams(wallet!);
-    await _fetchWalletData(wallet!);
-    return wallet!;
+    instance = await liquid_sdk.connect(req: req);
+    _initializeEventsStream(instance!);
+    _subscribeToSdkStreams(instance!);
+    await _fetchWalletData(instance!);
+    return instance!;
   }
 
   void disconnect(liquid_sdk.BindingLiquidSdk sdk) {

--- a/packages/flutter/example/pubspec.lock
+++ b/packages/flutter/example/pubspec.lock
@@ -218,10 +218,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: f54946fdb1fa7b01f780841937b1a80783a20b393485f3f6cdf336fd6f4705f2
+      sha256: f9f6597ac43cc262fa7d7f2e65259a6060c23a560525d1f2631be374540f2a9b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   glob:
     dependency: transitive
     description:
@@ -362,10 +362,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: bca87b0165ffd7cdb9cad8edd22d18d2201e886d9a9f19b4fb3452ea7df3a72a
+      sha256: "30c5aa827a6ae95ce2853cdc5fe3971daaac00f6f081c419c013f7f57bff2f5e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.6"
+    version: "2.2.7"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -394,10 +394,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   platform:
     dependency: transitive
     description:


### PR DESCRIPTION
Closes #376

`wallet` on helper class, `BreezLiquidSDK` that manages wallet connection & SDK stream management is renamed to `instance`.

#### Other changes to address CI issues:
- Updates dependencies to latest
- Generate Dart bindings